### PR TITLE
Fixed conditional to allow for variables in arrays

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -19,7 +19,7 @@
     state=present
     validate='visudo -cf %s'
   with_items: security_sudoers_passwordless
-  when: security_sudoers_passwordless
+  when: security_sudoers_passwordless | length > 0
 
 - name: Add configured user accounts to passworded sudoers.
   lineinfile: >
@@ -29,4 +29,4 @@
     state=present
     validate='visudo -cf %s'
   with_items: security_sudoers_passworded
-  when: security_sudoers_passworded
+  when: security_sudoers_passworded | length > 0


### PR DESCRIPTION
I keep getting "Error when evaluating conditional" on the "Add configured user accounts..." tasks. It works fine when I specify the users as strings, but not when I use a variable (in this case, I'm using `- "{{ deploy_user }}"`). 