### PR TITLE
Support different distro releases

### DIFF
--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -1,6 +1,6 @@
 Unattended-Upgrade::Automatic-Reboot "false";
 
 Unattended-Upgrade::Allowed-Origins {
-        "Ubuntu lucid-security";
-//      "Ubuntu lucid-updates";
+        "${distro_id}:${distro_codename}-security";
+//      "${distro_id}:${distro_codename}-updates";
 };

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -1,6 +1,6 @@
 Unattended-Upgrade::Automatic-Reboot "false";
 
 Unattended-Upgrade::Allowed-Origins {
-        "${distro_id}:${distro_codename}-security";
-//      "${distro_id}:${distro_codename}-updates";
+        "${distro_id} ${distro_codename}-security";
+//      "${distro_id} ${distro_codename}-updates";
 };


### PR DESCRIPTION
Should substitute variables instead of  "Lucid" for unattended updates.

https://help.ubuntu.com/community/AutomaticSecurityUpdates

AlbanAndrieu's fork has this line changed too.