### PR TITLE
Ensure that the string values are used for PermitRootLogin and PasswordAuthentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Available variables are listed below, along with default values (see `vars/main.
 
 The port through which you'd like SSH to be accessible. The default is port 22, but if you're operating a server on the open internet, and have no firewall blocking access to port 22, you'll quickly find that thousands of login attempts per day are not uncommon. You can change the port to a nonstandard port (e.g. 2849) if you want to avoid these thousands of automated penetration attempts.
 
-    security_ssh_password_authentication: no
-    security_ssh_permit_root_login: no
+    security_ssh_password_authentication: 'no'
+    security_ssh_permit_root_login: 'no'
 
 Security settings for SSH authentication. It's best to leave these both set to `no`, but there are times (especially during initial server configuration or when you don't have key-based authentication in place) when one or both may be safely set to `yes`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The port through which you'd like SSH to be accessible. The default is port 22, 
     security_ssh_password_authentication: 'no'
     security_ssh_permit_root_login: 'no'
 
-Security settings for SSH authentication. It's best to leave these both set to `no`, but there are times (especially during initial server configuration or when you don't have key-based authentication in place) when one or both may be safely set to `yes`.
+Security settings for SSH authentication. It's best to leave these both set to `'no'`, but there are times (especially during initial server configuration or when you don't have key-based authentication in place) when one or both may be safely set to `'yes'`.
 
     security_sudoers_passwordless: []
     security_sudoers_passworded: []


### PR DESCRIPTION
The values need to be wrapped in quotes so that the string values are used and passed directly into the template - i.e. `'yes'` or `'no'`.

This is done in defaults.yml, but the README doesn't have these so the boolean values are used, and `True` or `False` are inserted into the template instead - this prevents the ssh service from restarting as these aren't allowed values. README.md should be updated with the correct values.

I managed to lock myself out of my new Debian server a couple of times before I realised what was going on. Luckily I was able to connect via the Linode shell (Lish), and there's nothing on the server currently, but if people are adding this role to an existing server, they may accidentally lock themselves out of their server so this seems like quite a high priority issue IMO.