### PR TITLE
Initial Fedora support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ security_sudoers_passwordless: []
 security_sudoers_passworded: []
 
 security_autoupdate_enabled: true
+# Fedora 22+ uses DNF by default
+security_redhat_use_dnf: false

--- a/tasks/autoupdate-RedHat-DNF.yml
+++ b/tasks/autoupdate-RedHat-DNF.yml
@@ -1,0 +1,13 @@
+---
+- name: Install dnf-automatic.
+  dnf: name=dnf-automatic state=present
+
+- name: Turn on autoupdates.
+  lineinfile:
+    dest: "/etc/dnf/automatic.conf"
+    regexp: '^apply_updates = .+'
+    line: 'apply_updates = yes'
+  when: security_autoupdate_enabled
+
+- name: Ensure autoupdate service timer is running and enabled on boot.
+  service: name=dnf-automatic.timer state=started enabled=yes

--- a/tasks/fail2ban-RedHat-DNF.yml
+++ b/tasks/fail2ban-RedHat-DNF.yml
@@ -1,0 +1,3 @@
+---
+- name: Install fail2ban using DNF.
+  dnf: name=fail2ban state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,10 @@
 
 # Fail2Ban
 - include: fail2ban-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and not security_redhat_use_dnf
+
+- include: fail2ban-RedHat-DNF.yml
+  when: ansible_os_family == 'RedHat' and security_redhat_use_dnf
 
 - include: fail2ban-Debian.yml
   when: ansible_os_family == 'Debian'
@@ -17,7 +20,10 @@
 
 # Autoupdate
 - include: autoupdate-RedHat.yml
-  when: ansible_os_family == 'RedHat' and security_autoupdate_enabled
+  when: ansible_os_family == 'RedHat' and not security_redhat_use_dnf and security_autoupdate_enabled
+
+- include: autoupdate-RedHat-DNF.yml
+  when: ansible_os_family == 'RedHat' and security_redhat_use_dnf and security_autoupdate_enabled
 
 - include: autoupdate-Debian.yml
   when: ansible_os_family == 'Debian' and security_autoupdate_enabled

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,4 +1,6 @@
 - hosts: all
+  vars:
+    security_redhat_use_dnf: false
 
   pre_tasks:
     - name: Ensure build dependencies are installed (RedHat).
@@ -6,7 +8,14 @@
       with_items:
         - openssh-server
         - openssh-clients
-      when: ansible_os_family == 'RedHat'
+      when: ansible_os_family == 'RedHat' and not security_redhat_use_dnf
+
+    - name: Ensure build dependencies are installed (RedHat DNF).
+      dnf: 'name="{{ item }}" state=present'
+      with_items:
+        - openssh-server
+        - openssh-clients
+      when: ansible_os_family == 'RedHat' and security_redhat_use_dnf
 
     - name: Ensure build dependencies are installed (Debian).
       apt: 'name="{{ item }}" state=installed'


### PR DESCRIPTION
New Fedora (22+) uses `dnf` as default package manager. This adds an explicit switch to enable Fedora support.
