### PR TITLE
make fail2ban optional with security_fail2ban_enabled (default true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ A list of users who should be added to the sudoers file so they can run any comm
 
 Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgrades` (Debian-based systems). System restarts will not happen automatically in any case, and automatic upgrades are no excuse for sloppy patch and package management, but automatic updates can be helpful as yet another security measure.
 
+    security_fail2ban_enabled: true
+
+Wether to install/enable `fail2ban`
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ security_sudoers_passwordless: []
 security_sudoers_passworded: []
 
 security_autoupdate_enabled: true
+security_fail2ban_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,13 +4,14 @@
 
 # Fail2Ban
 - include: fail2ban-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and security_fail2ban_enabled
 
 - include: fail2ban-Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and security_fail2ban_enabled
 
 - name: Ensure fail2ban is running and enabled on boot.
   service: name=fail2ban state=started enabled=yes
+  when: security_fail2ban_enabled
 
 # SSH
 - include: ssh.yml


### PR DESCRIPTION
Hi Jeff,

Normally I let ConfigServer Firewall handle the brute force attacks. Do you mind this PR where fail2ban is optional (but enabled by default)?

Regards,

Barry