### PR TITLE
Replace `yum` module with `package`

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Security software installation and configuration.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.9
+  min_ansible_version: 2.0
   platforms:
     - name: EL
       versions:

--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install yum-cron.
-  yum: name=yum-cron state=present
+  package: name=yum-cron state=present
 
 - name: Ensure yum-cron is running and enabled on boot.
   service: name=yum-cron state=started enabled=yes

--- a/tasks/fail2ban-RedHat.yml
+++ b/tasks/fail2ban-RedHat.yml
@@ -1,3 +1,3 @@
 ---
 - name: Install fail2ban.
-  yum: name=fail2ban state=present enablerepo=epel
+  package: name=fail2ban state=present enablerepo=epel

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,7 +6,7 @@
       when: ansible_os_family == 'Debian'
 
     - name: Ensure build dependencies are installed (RedHat).
-      yum: 'name="{{ item }}" state=present'
+      package: 'name="{{ item }}" state=present'
       with_items:
         - openssh-server
         - openssh-clients


### PR DESCRIPTION
This commit replaces the use of `yum` module with `package`, which is
the "generic OS package manager" introduced in Ansible 2.0. This change
allows this role to be run with recent Fedora versions. This commit does
not configure automatic updates for Fedora, it just prevents a failure.
