### PR TITLE
add autoupdate blacklist option (for Debian/Ubuntu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ A list of users who should be added to the sudoers file so they can run any comm
 
 Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgrades` (Debian-based systems). System restarts will not happen automatically in any case, and automatic upgrades are no excuse for sloppy patch and package management, but automatic updates can be helpful as yet another security measure.
 
+    security_autoupdate_blacklist: []
+
+(Debian/Ubuntu only) A listing of packages that should no be automatically updated.
+
     security_autoupdate_mail_to: ""
     security_autoupdate_mail_on_error: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,5 +16,7 @@ security_autoupdate_enabled: true
 # Autoupdate mail settings used on Debian/Ubuntu only.
 security_autoupdate_mail_to: ""
 security_autoupdate_mail_on_error: true
-
+security_autoupdate_blacklist: []
 security_fail2ban_enabled: true
+
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,11 +12,10 @@ security_sudoers_passwordless: []
 security_sudoers_passworded: []
 
 security_autoupdate_enabled: true
+security_autoupdate_blacklist: []
 
 # Autoupdate mail settings used on Debian/Ubuntu only.
 security_autoupdate_mail_to: ""
 security_autoupdate_mail_on_error: true
-security_autoupdate_blacklist: []
+
 security_fail2ban_enabled: true
-
-

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -11,3 +11,9 @@ Unattended-Upgrade::Allowed-Origins {
         "${distro_id} ${distro_codename}-security";
 //      "${distro_id} ${distro_codename}-updates";
 };
+
+Unattended-Upgrade::Package-Blacklist{
+{% for package in security_autoupdate_blacklist %}
+      "{{package}}";
+{% endfor %}
+}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,7 +2,7 @@
 
   pre_tasks:
     - name: Update apt cache.
-      apt: update_cache=yes
+      apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
     - name: Ensure build dependencies are installed (RedHat).


### PR DESCRIPTION
This PR adds the ability to exclude packages from unattended-upgrades on Debian/Ubuntu systems. This can be convenient if there's packages installed on the system that require a more hands-on upgrade.

Tested on Debian Jessie.