### PR TITLE
sshd_config template

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -2,7 +2,7 @@
 - name: Update SSH configuration to be more secure.
   template:
     src: templates/sshd_config.j2
-    dest: /etc/ssh/sshd_config
+    dest: {{ security_ssh_config_path }}
     owner: root
     group: root
     mode: '0600'

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -2,7 +2,7 @@
 - name: Update SSH configuration to be more secure.
   template:
     src: templates/sshd_config.j2
-    dest: {{ security_ssh_config_path }}
+    dest: "{{ security_ssh_config_path }}"
     owner: root
     group: root
     mode: '0600'

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,27 +1,13 @@
 ---
 - name: Update SSH configuration to be more secure.
-  lineinfile:
-    dest: "{{ security_ssh_config_path }}"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-    state: present
-  with_items:
-    - regexp: "^PasswordAuthentication"
-      line: "PasswordAuthentication {{ security_ssh_password_authentication }}"
-    - regexp: "^PermitRootLogin"
-      line: "PermitRootLogin {{ security_ssh_permit_root_login }}"
-    - regexp: "^Port"
-      line: "Port {{ security_ssh_port }}"
-    - regexp: "^UseDNS"
-      line: "UseDNS {{ security_ssh_usedns }}"
-    - regexp: "^PermitEmptyPasswords"
-      line: "PermitEmptyPasswords {{ security_ssh_permit_empty_password }}"
-    - regexp: "^ChallengeResponseAuthentication"
-      line: "ChallengeResponseAuthentication {{ security_ssh_challenge_response_auth }}"
-    - regexp: "^GSSAPIAuthentication"
-      line: "GSSAPIAuthentication {{ security_ssh_gss_api_authentication }}"
-    - regexp: "^X11Forwarding"
-      line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
+  template:
+    src: templates/sshd_config.j2
+    dest: /etc/ssh/sshd_config
+    owner: root
+    group: root
+    mode: '0600'
+    validate: /usr/sbin/sshd -t -f %s
+    backup: yes
   notify: restart ssh
 
 - name: Add configured user accounts to passwordless sudoers.

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -1,0 +1,89 @@
+# {{ ansible_managed }}
+
+# What ports, IPs and protocols we listen for
+Port {{ security_ssh_port }}
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin {{ security_ssh_permit_root_login }}
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords {{ security_ssh_permit_empty_password }}
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication {{ security_ssh_challenge_response_auth }}
+
+# Change to no to disable tunnelled clear text passwords
+PasswordAuthentication {{ security_ssh_password_authentication }}
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+GSSAPIAuthentication {{ security_ssh_gss_api_authentication }}
+#GSSAPICleanupCredentials yes
+
+X11Forwarding {{ security_ssh_x11_forwarding }}
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+UseDNS {{ security_ssh_usedns }}
+PasswordAuthentication {{ security_ssh_password_authentication }}


### PR DESCRIPTION
This PR introduces a template for `/etc/ssh/sshd_config`, replacing the lineinfile approach.

I've noticed that using `lineinfile` will in some cases append changes to `sshd_config` and allow the possibility for manual changes which can lead to undesired results.

This commit adds existing variables into the default sshd_config, additions can be moved in later.


Tested locally and remotely on Debian Jessie.