### PR TITLE
Fixes #29 The use of 'include' for tasks has been deprecated

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Security software installation and configuration.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.9
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,10 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 # Fail2Ban
-- include: fail2ban-RedHat.yml
+- import_tasks: fail2ban-RedHat.yml
   when: ansible_os_family == 'RedHat' and security_fail2ban_enabled
 
-- include: fail2ban-Debian.yml
+- import_tasks: fail2ban-Debian.yml
   when: ansible_os_family == 'Debian' and security_fail2ban_enabled
 
 - name: Ensure fail2ban is running and enabled on boot.
@@ -14,11 +14,11 @@
   when: security_fail2ban_enabled
 
 # SSH
-- include: ssh.yml
+- import_tasks: ssh.yml
 
 # Autoupdate
-- include: autoupdate-RedHat.yml
+- import_tasks: autoupdate-RedHat.yml
   when: ansible_os_family == 'RedHat' and security_autoupdate_enabled
 
-- include: autoupdate-Debian.yml
+- import_tasks: autoupdate-Debian.yml
   when: ansible_os_family == 'Debian' and security_autoupdate_enabled


### PR DESCRIPTION
This change preserves the previous behavior.

> Before 2.0 all includes were ‘static’, executed at play compile
  time.

https://docs.ansible.com/ansible/latest/include_module.html