### PR TITLE
Support a larger range of options in the Unattended-Update config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,15 @@ Security settings for SSH authentication. It's best to leave these set to `"no"`
 
 A list of users who should be added to the sudoers file so they can run any command as root (via `sudo`) either without a password or requiring a password for each command, respectively.
 
+    security_fail2ban_enabled: true
+
+Wether to install/enable `fail2ban`. You might not want to use fail2ban if you're already using some other service for login and intrusion detection (e.g. [ConfigServer](http://configserver.com/cp/csf.html)).
+
     security_autoupdate_enabled: true
 
 Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgrades` (Debian-based systems). System restarts will not happen automatically in any case, and automatic upgrades are no excuse for sloppy patch and package management, but automatic updates can be helpful as yet another security measure.
+
+### AutoUpdates specific to Debian based distributions
 
     security_autoupdate_blacklist: []
 
@@ -58,9 +64,29 @@ Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgra
 
 (Debian/Ubuntu only) If `security_autoupdate_mail_to` is set to an non empty value, unattended upgrades will send an e-mail to that address when some error occurs. You may either set this to a full email: `ops@example.com` or to something like `root`, which will use `/etc/aliases` to route the message. If you set `security_autoupdate_mail_on_error` to `false` you'll get an email after every package install.
 
-    security_fail2ban_enabled: true
+### Autoupdates specific to Debian and Ubuntu releases
 
-Wether to install/enable `fail2ban`. You might not want to use fail2ban if you're already using some other service for login and intrusion detection (e.g. [ConfigServer](http://configserver.com/cp/csf.html)).
+The following settings will configure the Unattended-Upgrade configuration file to support more customization. Please see the template files and NOT the `vars/main.yml` (as setting these values at all in either direction will change whether they appear commented in the resulting file) for what these values will change. This has not been applied to all Debian Derivatives, only Debian and Ubuntu.
+
+    security_autoupdate_train_main: true
+    security_autoupdate_train_security: true
+    security_autoupdate_train_esm: true (Ubuntu only)
+    security_autoupdate_train_updates: false
+    security_autoupdate_train_proposed: false
+    security_autoupdate_devrelease: false (Ubuntu only)
+    security_autoupdate_auto_fix_interrupted_dpkg: false
+    security_autoupdate_minimal_steps: false
+    security_autoupdate_install_on_shutdown: true (Debian only)
+    security_autoupdate_install_on_shutdown: true
+    security_autoupdate_remove_unused_kernel_packages: false
+    security_autoupdate_remove_unused_dependencies: false
+    security_autoupdate_reboot: false
+    security_autoupdate_reboot_time: "02:00"
+    security_autoupdate_download_limit: 70
+    security_autoupdate_syslog_enable: false
+    security_autoupdate_syslog_facility: daemon
+    security_autoupdate_on_ac_only: true
+    security_autoupdate_on_non_metered: true
 
 ## Dependencies
 

--- a/tasks/autoupdate-Debian.yml
+++ b/tasks/autoupdate-Debian.yml
@@ -2,13 +2,18 @@
 - name: Install unattended upgrades package.
   package: name=unattended-upgrades state=present
 
-- name: Copy unattended-upgrades configuration files in place.
+- name: Copy 50unattended-upgrades configuration file in place.
   template:
-    src: "../templates/{{ item }}{% if ansible_distribution == 'Ubuntu' %}.ubuntu{% elif ansible_distribution == 'Debian' %}.debian{% endif %}.j2"
-    dest: "/etc/apt/apt.conf.d/{{ item }}"
+    src: "../templates/50unattended-upgrades{% if ansible_distribution == 'Ubuntu' %}.ubuntu{% elif ansible_distribution == 'Debian' %}.debian{% endif %}.j2"
+    dest: "/etc/apt/apt.conf.d/50unattended-upgrades"
     owner: root
     group: root
     mode: 0644
-  with_items:
-    - 10periodic
-    - 50unattended-upgrades
+
+- name: Copy 10periodic configuration file in place.
+  template:
+    src: "../templates/10periodic.j2"
+    dest: "/etc/apt/apt.conf.d/10periodic"
+    owner: root
+    group: root
+    mode: 0644

--- a/tasks/autoupdate-Debian.yml
+++ b/tasks/autoupdate-Debian.yml
@@ -4,7 +4,7 @@
 
 - name: Copy unattended-upgrades configuration files in place.
   template:
-    src: "../templates/{{ item }}.j2"
+    src: "../templates/{{ item }}{% if ansible_distribution == 'Ubuntu' %}.ubuntu{% elif ansible_distribution == 'Debian' %}.debian{% endif %}.j2"
     dest: "/etc/apt/apt.conf.d/{{ item }}"
     owner: root
     group: root

--- a/templates/50unattended-upgrades.debian.j2
+++ b/templates/50unattended-upgrades.debian.j2
@@ -1,0 +1,120 @@
+{# Based on latest version of the config file from https://github.com/mvo5/unattended-upgrades/blob/a0ecfba0e6e2974e01a351d788843da54234e2e6/data/50unattended-upgrades.Debian #}
+
+// Unattended-Upgrade::Origins-Pattern controls which packages are
+// upgraded.
+//
+// Lines below have the format format is "keyword=value,...".  A
+// package will be upgraded only if the values in its metadata match
+// all the supplied keywords in a line.  (In other words, omitted
+// keywords are wild cards.) The keywords originate from the Release
+// file, but several aliases are accepted.  The accepted keywords are:
+//   a,archive,suite (eg, "stable")
+//   c,component     (eg, "main", "contrib", "non-free")
+//   l,label         (eg, "Debian", "Debian-Security")
+//   o,origin        (eg, "Debian", "Unofficial Multimedia Packages")
+//   n,codename      (eg, "jessie", "jessie-updates")
+//     site          (eg, "http.debian.net")
+// The available values on the system are printed by the command
+// "apt-cache policy", and can be debugged by running
+// "unattended-upgrades -d" and looking at the log file.
+//
+// Within lines unattended-upgrades allows 2 macros whose values are
+// derived from /etc/debian_version:
+//   ${distro_id}            Installed origin.
+//   ${distro_codename}      Installed codename (eg, "buster")
+Unattended-Upgrade::Origins-Pattern {
+        // Codename based matching:
+        // This will follow the migration of a release through different
+        // archives (e.g. from testing to stable and later oldstable).
+        // Software will be the latest available for the named release,
+        // but the Debian release itself will not be automatically upgraded.
+{% if not security_autoupdate_train_updates | default('false') %}//{% endif %}      "origin=Debian,codename=${distro_codename}-updates";
+{% if not security_autoupdate_train_proposed | default('false') %}//{% endif %}      "origin=Debian,codename=${distro_codename}-proposed-updates";
+{% if not security_autoupdate_train_main | default('true') %}//{% endif %}        "origin=Debian,codename=${distro_codename},label=Debian";
+{% if not security_autoupdate_train_security | default('true') %}//{% endif %}      "origin=Debian,codename=${distro_codename},label=Debian-Security";
+
+        // Archive or Suite based matching:
+        // Note that this will silently match a different release after
+        // migration to the specified archive (e.g. testing becomes the
+        // new stable).
+//      "o=Debian,a=stable";
+//      "o=Debian,a=stable-updates";
+//      "o=Debian,a=proposed-updates";
+//      "o=Debian Backports,a=${distro_codename}-backports,l=Debian Backports";
+};
+
+// List of packages to not update (regexp are supported)
+Unattended-Upgrade::Package-Blacklist {
+{% for package in security_autoupdate_blacklist %}
+      "{{package}}";
+{% endfor %}
+//     "vim";
+//     "libc6";
+//     "libc6-dev";
+//     "libc6-i686";
+};
+
+// This option allows you to control if on a unclean dpkg exit
+// unattended-upgrades will automatically run 
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+{% if security_autoupdate_auto_fix_interrupted_dpkg is not defined %}//{% endif %}Unattended-Upgrade::AutoFixInterruptedDpkg "{% if security_autoupdate_auto_fix_interrupted_dpkg | default('false') %}true{% else %}false{% endif %}";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGTERM. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+{% if security_autoupdate_minimal_steps is not defined %}//{% endif %}Unattended-Upgrade::MinimalSteps "{% if security_autoupdate_minimal_steps | default('false') %}true{% else %}false{% endif %}";
+
+// Install all unattended-upgrades when the machine is shutting down
+// instead of doing it in the background while the machine is running
+// This will (obviously) make shutdown slower
+{% if security_autoupdate_install_on_shutdown is not defined %}//{% endif %}Unattended-Upgrade::InstallOnShutdown "{% if security_autoupdate_install_on_shutdown | default('true') %}true{% else %}false{% endif %}";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+{% if security_autoupdate_mail_to is not defined %}//{% endif %}Unattended-Upgrade::Mail "{{ security_autoupdate_mail_to | default('root') }}";
+
+// Set this value to "true" to get emails only on errors. Default
+// is to always send a mail if Unattended-Upgrade::Mail is set
+{% if security_autoupdate_mail_on_error is not defined %}//{% endif %}Unattended-Upgrade::MailOnlyOnError "{% if security_autoupdate_mail_on_error | default('true') %}true{% else %}false{% endif %}";
+
+// Remove unused automatically installed kernel-related packages
+// (kernel images, kernel headers and kernel version locked tools).
+{% if security_autoupdate_remove_unused_kernel_packages is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Kernel-Packages "{% if security_autoupdate_remove_unused_kernel_packages | default('false') %}true{% else %}false{% endif %}";
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+{% if security_autoupdate_remove_unused_dependencies is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Dependencies "{% if security_autoupdate_remove_unused_dependencies | default('false') %}true{% else %}false{% endif %}"
+
+// Automatically reboot *WITHOUT CONFIRMATION* if
+//  the file /var/run/reboot-required is found after the upgrade 
+{% if security_autoupdate_reboot is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot "{% if security_autoupdate_reboot | default('false') %}true{% else %}false{% endif %}";
+
+// Automatically reboot even if there are users currently logged in.
+{% if security_autoupdate_reboot_with_users is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot-WithUsers "{% if security_autoupdate_reboot | default('true') %}true{% else %}false{% endif %}";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+{% if security_autoupdate_reboot_time is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot-Time "{{ security_autoupdate_reboot_time | default('02:00') }}";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+{% if security_autoupdate_download_limit is not defined %}//{% endif %}Acquire::http::Dl-Limit "{{ security_autoupdate_download_limit | default('70') }}";
+
+// Enable logging to syslog. Default is False
+{% if security_autoupdate_syslog_enable is not defined %}//{% endif %}Unattended-Upgrade::SyslogEnable "{% if security_autoupdate_syslog_enable | default('false') %}true{% else %}false{% endif %}";
+
+// Specify syslog facility. Default is daemon
+{% if security_autoupdate_syslog_facility is not defined %}//{% endif %}Unattended-Upgrade::SyslogFacility "{{ security_autoupdate_syslog_facility | default('daemon') }}";
+
+// Download and install upgrades only on AC power
+// (i.e. skip or gracefully stop updates on battery)
+{% if security_autoupdate_on_ac_only is not defined %}//{% endif %}Unattended-Upgrade::OnlyOnACPower "{% if security_autoupdate_on_ac_only | default('true') %}true{% else %}false{% endif %}";
+
+// Download and install upgrades only on non-metered connection
+// (i.e. skip or gracefully stop updates on a metered connection)
+{% if security_autoupdate_on_non_metered is not defined %}//{% endif %}Unattended-Upgrade::Skip-Updates-On-Metered-Connections "{% if security_autoupdate_on_non_metered | default('true') %}true{% else %}false{% endif %}";

--- a/templates/50unattended-upgrades.debian.j2
+++ b/templates/50unattended-upgrades.debian.j2
@@ -28,10 +28,10 @@ Unattended-Upgrade::Origins-Pattern {
         // archives (e.g. from testing to stable and later oldstable).
         // Software will be the latest available for the named release,
         // but the Debian release itself will not be automatically upgraded.
-{% if not security_autoupdate_train_updates | default('false') %}//{% endif %}      "origin=Debian,codename=${distro_codename}-updates";
-{% if not security_autoupdate_train_proposed | default('false') %}//{% endif %}      "origin=Debian,codename=${distro_codename}-proposed-updates";
-{% if not security_autoupdate_train_main | default('true') %}//{% endif %}        "origin=Debian,codename=${distro_codename},label=Debian";
-{% if not security_autoupdate_train_security | default('true') %}//{% endif %}      "origin=Debian,codename=${distro_codename},label=Debian-Security";
+{% if not security_autoupdate_train_updates | default(false) %}//{% endif %}      "origin=Debian,codename=${distro_codename}-updates";
+{% if not security_autoupdate_train_proposed | default(false) %}//{% endif %}      "origin=Debian,codename=${distro_codename}-proposed-updates";
+{% if not security_autoupdate_train_main | default(true) %}//{% endif %}        "origin=Debian,codename=${distro_codename},label=Debian";
+{% if not security_autoupdate_train_security | default(true) %}//{% endif %}      "origin=Debian,codename=${distro_codename},label=Debian-Security";
 
         // Archive or Suite based matching:
         // Note that this will silently match a different release after
@@ -58,18 +58,18 @@ Unattended-Upgrade::Package-Blacklist {
 // unattended-upgrades will automatically run 
 //   dpkg --force-confold --configure -a
 // The default is true, to ensure updates keep getting installed
-{% if security_autoupdate_auto_fix_interrupted_dpkg is not defined %}//{% endif %}Unattended-Upgrade::AutoFixInterruptedDpkg "{% if security_autoupdate_auto_fix_interrupted_dpkg | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_auto_fix_interrupted_dpkg is not defined %}//{% endif %}Unattended-Upgrade::AutoFixInterruptedDpkg "{% if security_autoupdate_auto_fix_interrupted_dpkg | default(false) %}true{% else %}false{% endif %}";
 
 // Split the upgrade into the smallest possible chunks so that
 // they can be interrupted with SIGTERM. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
-{% if security_autoupdate_minimal_steps is not defined %}//{% endif %}Unattended-Upgrade::MinimalSteps "{% if security_autoupdate_minimal_steps | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_minimal_steps is not defined %}//{% endif %}Unattended-Upgrade::MinimalSteps "{% if security_autoupdate_minimal_steps | default(false) %}true{% else %}false{% endif %}";
 
 // Install all unattended-upgrades when the machine is shutting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
-{% if security_autoupdate_install_on_shutdown is not defined %}//{% endif %}Unattended-Upgrade::InstallOnShutdown "{% if security_autoupdate_install_on_shutdown | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_install_on_shutdown is not defined %}//{% endif %}Unattended-Upgrade::InstallOnShutdown "{% if security_autoupdate_install_on_shutdown | default(true) %}true{% else %}false{% endif %}";
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
@@ -79,22 +79,22 @@ Unattended-Upgrade::Package-Blacklist {
 
 // Set this value to "true" to get emails only on errors. Default
 // is to always send a mail if Unattended-Upgrade::Mail is set
-{% if security_autoupdate_mail_on_error is not defined %}//{% endif %}Unattended-Upgrade::MailOnlyOnError "{% if security_autoupdate_mail_on_error | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_mail_on_error is not defined %}//{% endif %}Unattended-Upgrade::MailOnlyOnError "{% if security_autoupdate_mail_on_error | default(true) %}true{% else %}false{% endif %}";
 
 // Remove unused automatically installed kernel-related packages
 // (kernel images, kernel headers and kernel version locked tools).
-{% if security_autoupdate_remove_unused_kernel_packages is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Kernel-Packages "{% if security_autoupdate_remove_unused_kernel_packages | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_remove_unused_kernel_packages is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Kernel-Packages "{% if security_autoupdate_remove_unused_kernel_packages | default(false) %}true{% else %}false{% endif %}";
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
-{% if security_autoupdate_remove_unused_dependencies is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Dependencies "{% if security_autoupdate_remove_unused_dependencies | default('false') %}true{% else %}false{% endif %}"
+{% if security_autoupdate_remove_unused_dependencies is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Dependencies "{% if security_autoupdate_remove_unused_dependencies | default(false) %}true{% else %}false{% endif %}"
 
 // Automatically reboot *WITHOUT CONFIRMATION* if
 //  the file /var/run/reboot-required is found after the upgrade 
-{% if security_autoupdate_reboot is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot "{% if security_autoupdate_reboot | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_reboot is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot "{% if security_autoupdate_reboot | default(false) %}true{% else %}false{% endif %}";
 
 // Automatically reboot even if there are users currently logged in.
-{% if security_autoupdate_reboot_with_users is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot-WithUsers "{% if security_autoupdate_reboot | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_reboot_with_users is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot-WithUsers "{% if security_autoupdate_reboot | default(true) %}true{% else %}false{% endif %}";
 
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
@@ -106,15 +106,15 @@ Unattended-Upgrade::Package-Blacklist {
 {% if security_autoupdate_download_limit is not defined %}//{% endif %}Acquire::http::Dl-Limit "{{ security_autoupdate_download_limit | default('70') }}";
 
 // Enable logging to syslog. Default is False
-{% if security_autoupdate_syslog_enable is not defined %}//{% endif %}Unattended-Upgrade::SyslogEnable "{% if security_autoupdate_syslog_enable | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_syslog_enable is not defined %}//{% endif %}Unattended-Upgrade::SyslogEnable "{% if security_autoupdate_syslog_enable | default(false) %}true{% else %}false{% endif %}";
 
 // Specify syslog facility. Default is daemon
 {% if security_autoupdate_syslog_facility is not defined %}//{% endif %}Unattended-Upgrade::SyslogFacility "{{ security_autoupdate_syslog_facility | default('daemon') }}";
 
 // Download and install upgrades only on AC power
 // (i.e. skip or gracefully stop updates on battery)
-{% if security_autoupdate_on_ac_only is not defined %}//{% endif %}Unattended-Upgrade::OnlyOnACPower "{% if security_autoupdate_on_ac_only | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_on_ac_only is not defined %}//{% endif %}Unattended-Upgrade::OnlyOnACPower "{% if security_autoupdate_on_ac_only | default(true) %}true{% else %}false{% endif %}";
 
 // Download and install upgrades only on non-metered connection
 // (i.e. skip or gracefully stop updates on a metered connection)
-{% if security_autoupdate_on_non_metered is not defined %}//{% endif %}Unattended-Upgrade::Skip-Updates-On-Metered-Connections "{% if security_autoupdate_on_non_metered | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_on_non_metered is not defined %}//{% endif %}Unattended-Upgrade::Skip-Updates-On-Metered-Connections "{% if security_autoupdate_on_non_metered | default(true) %}true{% else %}false{% endif %}";

--- a/templates/50unattended-upgrades.ubuntu.j2
+++ b/templates/50unattended-upgrades.ubuntu.j2
@@ -6,15 +6,15 @@
 // from non-security sources (e.g. chromium). By allowing the release
 // pocket these get automatically pulled in.
 Unattended-Upgrade::Allowed-Origins {
-{% if not security_autoupdate_train_main | default('true') %}//{% endif %}        "${distro_id}:${distro_codename}";
-{% if not security_autoupdate_train_security | default('true') %}//{% endif %}        "${distro_id}:${distro_codename}-security";
+{% if not security_autoupdate_train_main | default(true) %}//{% endif %}        "${distro_id}:${distro_codename}";
+{% if not security_autoupdate_train_security | default(true) %}//{% endif %}        "${distro_id}:${distro_codename}-security";
         // Extended Security Maintenance; doesn't necessarily exist for
         // every release and this system may not have it installed, but if
         // available, the policy for updates is such that unattended-upgrades
         // should also install from here by default.
-{% if not security_autoupdate_train_esm | default('true') %}//{% endif %}        "${distro_id}ESM:${distro_codename}";
-{% if not security_autoupdate_train_updates | default('false') %}//{% endif %}      "${distro_id}:${distro_codename}-updates";
-{% if not security_autoupdate_train_proposed | default('false') %}//{% endif %}      "${distro_id}:${distro_codename}-proposed";
+{% if not security_autoupdate_train_esm | default(true) %}//{% endif %}        "${distro_id}ESM:${distro_codename}";
+{% if not security_autoupdate_train_updates | default(false) %}//{% endif %}      "${distro_id}:${distro_codename}-updates";
+{% if not security_autoupdate_train_proposed | default(false) %}//{% endif %}      "${distro_id}:${distro_codename}-proposed";
 //      "${distro_id}:${distro_codename}-backports";
 };
 
@@ -31,24 +31,24 @@ Unattended-Upgrade::Package-Blacklist {
 
 // This option will controls whether the development release of Ubuntu will be
 // upgraded automatically.
-Unattended-Upgrade::DevRelease "{% if security_autoupdate_devrelease | default('false') %}true{% else %}false{% endif %}";
+Unattended-Upgrade::DevRelease "{% if security_autoupdate_devrelease | default(false) %}true{% else %}false{% endif %}";
 
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
 // The default is true, to ensure updates keep getting installed
-{% if security_autoupdate_auto_fix_interrupted_dpkg is not defined %}//{% endif %}Unattended-Upgrade::AutoFixInterruptedDpkg "{% if security_autoupdate_auto_fix_interrupted_dpkg | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_auto_fix_interrupted_dpkg is not defined %}//{% endif %}Unattended-Upgrade::AutoFixInterruptedDpkg "{% if security_autoupdate_auto_fix_interrupted_dpkg | default(false) %}true{% else %}false{% endif %}";
 
 // Split the upgrade into the smallest possible chunks so that
 // they can be interrupted with SIGTERM. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
-{% if security_autoupdate_minimal_steps is not defined %}//{% endif %}Unattended-Upgrade::MinimalSteps "{% if security_autoupdate_minimal_steps | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_minimal_steps is not defined %}//{% endif %}Unattended-Upgrade::MinimalSteps "{% if security_autoupdate_minimal_steps | default(false) %}true{% else %}false{% endif %}";
 
 // Install all unattended-upgrades when the machine is shutting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
-{% if security_autoupdate_install_on_shutdown is not defined %}//{% endif %}Unattended-Upgrade::InstallOnShutdown "{% if security_autoupdate_install_on_shutdown | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_install_on_shutdown is not defined %}//{% endif %}Unattended-Upgrade::InstallOnShutdown "{% if security_autoupdate_install_on_shutdown | default(true) %}true{% else %}false{% endif %}";
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
@@ -58,19 +58,19 @@ Unattended-Upgrade::DevRelease "{% if security_autoupdate_devrelease | default('
 
 // Set this value to "true" to get emails only on errors. Default
 // is to always send a mail if Unattended-Upgrade::Mail is set
-{% if security_autoupdate_mail_on_error is not defined %}//{% endif %}Unattended-Upgrade::MailOnlyOnError "{% if security_autoupdate_mail_on_error | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_mail_on_error is not defined %}//{% endif %}Unattended-Upgrade::MailOnlyOnError "{% if security_autoupdate_mail_on_error | default(true) %}true{% else %}false{% endif %}";
 
 // Remove unused automatically installed kernel-related packages
 // (kernel images, kernel headers and kernel version locked tools).
-{% if security_autoupdate_remove_unused_kernel_packages is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Kernel-Packages "{% if security_autoupdate_remove_unused_kernel_packages | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_remove_unused_kernel_packages is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Kernel-Packages "{% if security_autoupdate_remove_unused_kernel_packages | default(false) %}true{% else %}false{% endif %}";
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
-{% if security_autoupdate_remove_unused_dependencies is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Dependencies "{% if security_autoupdate_remove_unused_dependencies | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_remove_unused_dependencies is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Dependencies "{% if security_autoupdate_remove_unused_dependencies | default(false) %}true{% else %}false{% endif %}";
 
 // Automatically reboot *WITHOUT CONFIRMATION*
 //  if the file /var/run/reboot-required is found after the upgrade
-{% if security_autoupdate_reboot is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot "{% if security_autoupdate_reboot | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_reboot is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot "{% if security_autoupdate_reboot | default(false) %}true{% else %}false{% endif %}";
 
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
@@ -82,15 +82,15 @@ Unattended-Upgrade::DevRelease "{% if security_autoupdate_devrelease | default('
 {% if security_autoupdate_download_limit is not defined %}//{% endif %}Acquire::http::Dl-Limit "{{ security_autoupdate_download_limit | default('70') }}";
 
 // Enable logging to syslog. Default is False
-{% if security_autoupdate_syslog_enable is not defined %}//{% endif %}Unattended-Upgrade::SyslogEnable "{% if security_autoupdate_syslog_enable | default('false') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_syslog_enable is not defined %}//{% endif %}Unattended-Upgrade::SyslogEnable "{% if security_autoupdate_syslog_enable | default(false) %}true{% else %}false{% endif %}";
 
 // Specify syslog facility. Default is daemon
 {% if security_autoupdate_syslog_facility is not defined %}//{% endif %}Unattended-Upgrade::SyslogFacility "{{ security_autoupdate_syslog_facility | default('daemon') }}";
 
 // Download and install upgrades only on AC power
 // (i.e. skip or gracefully stop updates on battery)
-{% if security_autoupdate_on_ac_only is not defined %}//{% endif %}Unattended-Upgrade::OnlyOnACPower "{% if security_autoupdate_on_ac_only | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_on_ac_only is not defined %}//{% endif %}Unattended-Upgrade::OnlyOnACPower "{% if security_autoupdate_on_ac_only | default(true) %}true{% else %}false{% endif %}";
 
 // Download and install upgrades only on non-metered connection
 // (i.e. skip or gracefully stop updates on a metered connection)
-{% if security_autoupdate_on_non_metered is not defined %}//{% endif %}Unattended-Upgrade::Skip-Updates-On-Metered-Connections "{% if security_autoupdate_on_non_metered | default('true') %}true{% else %}false{% endif %}";
+{% if security_autoupdate_on_non_metered is not defined %}//{% endif %}Unattended-Upgrade::Skip-Updates-On-Metered-Connections "{% if security_autoupdate_on_non_metered | default(true) %}true{% else %}false{% endif %}";

--- a/templates/50unattended-upgrades.ubuntu.j2
+++ b/templates/50unattended-upgrades.ubuntu.j2
@@ -1,0 +1,96 @@
+{# Based on latest version of the config file from https://github.com/mvo5/unattended-upgrades/blob/a0ecfba0e6e2974e01a351d788843da54234e2e6/data/50unattended-upgrades.Ubuntu #}
+
+// Automatically upgrade packages from these (origin:archive) pairs
+//
+// Note that in Ubuntu security updates may pull in new dependencies
+// from non-security sources (e.g. chromium). By allowing the release
+// pocket these get automatically pulled in.
+Unattended-Upgrade::Allowed-Origins {
+{% if not security_autoupdate_train_main | default('true') %}//{% endif %}        "${distro_id}:${distro_codename}";
+{% if not security_autoupdate_train_security | default('true') %}//{% endif %}        "${distro_id}:${distro_codename}-security";
+        // Extended Security Maintenance; doesn't necessarily exist for
+        // every release and this system may not have it installed, but if
+        // available, the policy for updates is such that unattended-upgrades
+        // should also install from here by default.
+{% if not security_autoupdate_train_esm | default('true') %}//{% endif %}        "${distro_id}ESM:${distro_codename}";
+{% if not security_autoupdate_train_updates | default('false') %}//{% endif %}      "${distro_id}:${distro_codename}-updates";
+{% if not security_autoupdate_train_proposed | default('false') %}//{% endif %}      "${distro_id}:${distro_codename}-proposed";
+//      "${distro_id}:${distro_codename}-backports";
+};
+
+// List of packages to not update (regexp are supported)
+Unattended-Upgrade::Package-Blacklist {
+{% for package in security_autoupdate_blacklist %}
+      "{{package}}";
+{% endfor %}
+//      "vim";
+//      "libc6";
+//      "libc6-dev";
+//      "libc6-i686";
+};
+
+// This option will controls whether the development release of Ubuntu will be
+// upgraded automatically.
+Unattended-Upgrade::DevRelease "{% if security_autoupdate_devrelease | default('false') %}true{% else %}false{% endif %}";
+
+// This option allows you to control if on a unclean dpkg exit
+// unattended-upgrades will automatically run
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+{% if security_autoupdate_auto_fix_interrupted_dpkg is not defined %}//{% endif %}Unattended-Upgrade::AutoFixInterruptedDpkg "{% if security_autoupdate_auto_fix_interrupted_dpkg | default('false') %}true{% else %}false{% endif %}";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGTERM. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+{% if security_autoupdate_minimal_steps is not defined %}//{% endif %}Unattended-Upgrade::MinimalSteps "{% if security_autoupdate_minimal_steps | default('false') %}true{% else %}false{% endif %}";
+
+// Install all unattended-upgrades when the machine is shutting down
+// instead of doing it in the background while the machine is running
+// This will (obviously) make shutdown slower
+{% if security_autoupdate_install_on_shutdown is not defined %}//{% endif %}Unattended-Upgrade::InstallOnShutdown "{% if security_autoupdate_install_on_shutdown | default('true') %}true{% else %}false{% endif %}";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+{% if security_autoupdate_mail_to is not defined %}//{% endif %}Unattended-Upgrade::Mail "{{ security_autoupdate_mail_to | default('root') }}";
+
+// Set this value to "true" to get emails only on errors. Default
+// is to always send a mail if Unattended-Upgrade::Mail is set
+{% if security_autoupdate_mail_on_error is not defined %}//{% endif %}Unattended-Upgrade::MailOnlyOnError "{% if security_autoupdate_mail_on_error | default('true') %}true{% else %}false{% endif %}";
+
+// Remove unused automatically installed kernel-related packages
+// (kernel images, kernel headers and kernel version locked tools).
+{% if security_autoupdate_remove_unused_kernel_packages is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Kernel-Packages "{% if security_autoupdate_remove_unused_kernel_packages | default('false') %}true{% else %}false{% endif %}";
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+{% if security_autoupdate_remove_unused_dependencies is not defined %}//{% endif %}Unattended-Upgrade::Remove-Unused-Dependencies "{% if security_autoupdate_remove_unused_dependencies | default('false') %}true{% else %}false{% endif %}";
+
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade
+{% if security_autoupdate_reboot is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot "{% if security_autoupdate_reboot | default('false') %}true{% else %}false{% endif %}";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+{% if security_autoupdate_reboot_time is not defined %}//{% endif %}Unattended-Upgrade::Automatic-Reboot-Time "{{ security_autoupdate_reboot_time | default('02:00') }}";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+{% if security_autoupdate_download_limit is not defined %}//{% endif %}Acquire::http::Dl-Limit "{{ security_autoupdate_download_limit | default('70') }}";
+
+// Enable logging to syslog. Default is False
+{% if security_autoupdate_syslog_enable is not defined %}//{% endif %}Unattended-Upgrade::SyslogEnable "{% if security_autoupdate_syslog_enable | default('false') %}true{% else %}false{% endif %}";
+
+// Specify syslog facility. Default is daemon
+{% if security_autoupdate_syslog_facility is not defined %}//{% endif %}Unattended-Upgrade::SyslogFacility "{{ security_autoupdate_syslog_facility | default('daemon') }}";
+
+// Download and install upgrades only on AC power
+// (i.e. skip or gracefully stop updates on battery)
+{% if security_autoupdate_on_ac_only is not defined %}//{% endif %}Unattended-Upgrade::OnlyOnACPower "{% if security_autoupdate_on_ac_only | default('true') %}true{% else %}false{% endif %}";
+
+// Download and install upgrades only on non-metered connection
+// (i.e. skip or gracefully stop updates on a metered connection)
+{% if security_autoupdate_on_non_metered is not defined %}//{% endif %}Unattended-Upgrade::Skip-Updates-On-Metered-Connections "{% if security_autoupdate_on_non_metered | default('true') %}true{% else %}false{% endif %}";


### PR DESCRIPTION
* Applies only to Debian and Ubuntu. Other versions will see no changes
* Uses the upstream config file to ensure all comments are available.
* Toggles comment status and value for all available options in the config file
* Updated readme with the new values