### PR TITLE
Add instruction to install epel-release before fail2ban on RedHat

### DIFF
--- a/tasks/fail2ban-RedHat.yml
+++ b/tasks/fail2ban-RedHat.yml
@@ -1,3 +1,6 @@
 ---
+- name: Install EPEL for fail2ban installation
+  package: name=epel-release state=present
+
 - name: Install fail2ban.
   package: name=fail2ban state=present enablerepo=epel


### PR DESCRIPTION
The following error appears on VMs without epel-release installed by default:
`fatal: [example.com]: FAILED! => {"changed": false, "msg": "Error setting/accessing repos: Error getting repository data for epel, repository not found"}`

The following change in the code fixed the problem.