### PR TITLE
 Add support for autoupdate blacklist + mail on RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgra
 
     security_autoupdate_blacklist: []
 
-(Debian/Ubuntu only) A listing of packages that should not be automatically updated.
+A listing of packages that should not be automatically updated.
 
     security_autoupdate_reboot: false
 
@@ -64,7 +64,7 @@ Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgra
     security_autoupdate_mail_to: ""
     security_autoupdate_mail_on_error: true
 
-(Debian/Ubuntu only) If `security_autoupdate_mail_to` is set to an non empty value, unattended upgrades will send an e-mail to that address when some error occurs. You may either set this to a full email: `ops@example.com` or to something like `root`, which will use `/etc/aliases` to route the message. If you set `security_autoupdate_mail_on_error` to `false` you'll get an email after every package install.
+(security_auto_update_mail_on_error = Debian/Ubuntu only) If `security_autoupdate_mail_to` is set to an non empty value, unattended upgrades will send an e-mail to that address when some error occurs. You may either set this to a full email: `ops@example.com` or to something like `root`, which will use `/etc/aliases` to route the message. If you set `security_autoupdate_mail_on_error` to `false` you'll get an email after every package install.
 
     security_fail2ban_enabled: true
 

--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -5,9 +5,13 @@
 - name: Ensure yum-cron is running and enabled on boot.
   service: name=yum-cron state=started enabled=yes
 
-- name: Configure autoupdates (RHEL 7).
-  lineinfile:
-    dest: "/etc/yum/yum-cron.conf"
-    regexp: '^apply_updates = .+'
-    line: 'apply_updates = yes'
-  when: security_autoupdate_enabled and ansible_distribution_major_version | int == 7
+- name: Configure autoupdates (RHEL 7) and copy yum-cron configuration files in place.
+  template:
+    src: "../templates/{{ item }}.j2"
+    dest: "/etc/yum/{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - yum-cron.conf
+  when: security_autoupdate_enabled

--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -14,4 +14,4 @@
     mode: 0644
   with_items:
     - yum-cron.conf
-  when: security_autoupdate_enabled
+  when: security_autoupdate_enabled and ansible_distribution_major_version | int == 7

--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -1,0 +1,91 @@
+[commands]
+#  What kind of update to use:
+# default                            = yum upgrade
+# security                           = yum --security upgrade
+# security-severity:Critical         = yum --sec-severity=Critical upgrade
+# minimal                            = yum --bugfix update-minimal
+# minimal-security                   = yum --security update-minimal
+# minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
+update_cmd = default
+
+# Whether a message should be emitted when updates are available,
+# were downloaded, or applied.
+update_messages = yes
+
+# Whether updates should be downloaded when they are available.
+download_updates = yes
+
+# Whether updates should be applied when they are available.  Note
+# that download_updates must also be yes for the update to be applied.
+{% if security_autoupdate_enabled %}
+apply_updates = yes
+{% else %}
+apply_updates = no
+{% endif %}
+
+# Maximum amout of time to randomly sleep, in minutes.  The program
+# will sleep for a random amount of time between 0 and random_sleep
+# minutes before running.  This is useful for e.g. staggering the
+# times that multiple systems will access update servers.  If
+# random_sleep is 0 or negative, the program will run immediately.
+# 6*60 = 360
+random_sleep = 360
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  If
+# system_name is None, the hostname will be used.
+system_name = None
+
+# How to send messages.  Valid options are stdio and email.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = stdio,email
+
+# The width, in characters, that messages that are emitted should be
+# formatted to.
+output_width = 80
+
+
+[email]
+# The address to send email messages from.
+# NOTE: 'localhost' will be replaced with the value of system_name.
+email_from = root@localhost
+
+# List of addresses to send messages to.
+{% if security_autoupdate_mail_to %}
+email_to = {{ security_autoupdate_mail_to }}
+{% else %}
+email_to = root@localhost
+{% endif %}
+
+# Name of the host to connect to to send email messages.
+email_host = localhost
+
+
+[groups]
+# NOTE: This only works when group_command != objects, which is now the default
+# List of groups to update
+group_list = None
+
+# The types of group packages to install
+group_package_types = mandatory, default
+
+[base]
+# This section overrides yum.conf
+
+# Use this to filter Yum core messages
+# -4: critical
+# -3: critical+errors
+# -2: critical+errors+warnings (default)
+debuglevel = -2
+
+skip_broken = True
+mdpolicy = group:main
+
+# Uncomment to auto-import new gpg keys (dangerous)
+# assumeyes = True
+
+exclude: {% for package in security_autoupdate_blacklist -%}{{package}} {% endfor %}


### PR DESCRIPTION
I've added support for the autoupdate blacklist and mail feature on Red Hat machines (was only available on Debian/Ubuntu until now).