### PR TITLE
Fix #41 ansible lint error

### DIFF
--- a/tasks/autoupdate-Debian.yml
+++ b/tasks/autoupdate-Debian.yml
@@ -4,7 +4,7 @@
 
 - name: Copy unattended-upgrades configuration files in place.
   template:
-    src: "../templates/{{ item }}.j2"
+    src: "{{ item }}.j2"
     dest: "/etc/apt/apt.conf.d/{{ item }}"
     owner: root
     group: root


### PR DESCRIPTION
ansible-lint complains about relative template task using relative
path. We replaced the relative path by just the name of the template
(by default ansible use template from the role directories).