### PR TITLE
Fixes #58: configure Fail2ban sshd port, if enabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,4 @@ security_autoupdate_mail_to: ""
 security_autoupdate_mail_on_error: true
 
 security_fail2ban_enabled: true
+security_fail2ban_custom_configuration_template: "jail.local.j2"

--- a/tasks/fail2ban-configuration.yml
+++ b/tasks/fail2ban-configuration.yml
@@ -1,0 +1,8 @@
+---
+- name: Copy fail2ban custom configuration file into place.
+  template:
+    src: "{{ security_fail2ban_custom_configuration_template }}"
+    dest: /etc/fail2ban/jail.local
+    owner: root
+    group: root
+    mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,10 @@
     - ansible_os_family == 'Debian'
     - security_fail2ban_enabled | bool
 
+- include_tasks: fail2ban-configuration.yml
+  when:
+    - security_fail2ban_enabled | bool
+
 - name: Ensure fail2ban is running and enabled on boot.
   service: name=fail2ban state=started enabled=yes
   when: security_fail2ban_enabled | bool

--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -2,12 +2,3 @@
 enabled = true
 port    = {{ security_ssh_port }}
 filter  = sshd
-
-[ssh-ddos]
-enabled = true
-port    = {{ security_ssh_port }}
-filter  = sshd-ddos
-
-[recidive]
-enabled = true
-filter  = recidive

--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -1,0 +1,13 @@
+[sshd]
+enabled = true
+port    = {{ security_ssh_port }}
+filter  = sshd
+
+[ssh-ddos]
+enabled = true
+port    = {{ security_ssh_port }}
+filter  = sshd-ddos
+
+[recidive]
+enabled = true
+filter  = recidive


### PR DESCRIPTION
Enhance / fix Fail2ban configuration (ssh port)
- Configure sshd jail port through `jail.local` file
- Add possibility to override `jail.local` fail2ban configuration file