### PR TITLE
Fixes #61 - Validate sshd configuration file in lineinfile task

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,10 +1,15 @@
 ---
+- name: Ensure sshd service is started
+  systemd:
+    name: sshd
+    state: started
 - name: Update SSH configuration to be more secure.
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present
+    validate: 'sshd -T -f %s'
   with_items:
     - regexp: "^PasswordAuthentication"
       line: "PasswordAuthentication {{ security_ssh_password_authentication }}"


### PR DESCRIPTION
Validating the sshd configuration file without starting sshd service first is generating this error:
`
failed to validate: rc:1 error:Could not load host key: /etc/ssh/ssh_host_rsa_key\r\n
`

I added these lines, as suggested by @FinalDes in https://github.com/geerlingguy/ansible-for-devops/issues/273. 
```
- name: Ensure sshd service is started
  become: true
  systemd:
    name: sshd
    state: started
```

Starting sshd service before validing configuration is needed to generate host keys.

I could replace `systemd` module by `service` to ensure compatibility with more distributions, although tests are green for supported one (centos/ubuntu/debian): https://travis-ci.org/github/f-lopes/ansible-role-security/builds/691274972. Let me now.