### PR TITLE
Configure upgrade_type on /etc/dnf/automatic.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,4 +21,7 @@ security_autoupdate_reboot_time: "03:00"
 security_autoupdate_mail_to: ""
 security_autoupdate_mail_on_error: true
 
+# DNF autoupdate configuration
+security_dnf_upgrade_type: "default"
+
 security_fail2ban_enabled: true

--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -32,3 +32,13 @@
   when:
     - security_autoupdate_enabled
     - ansible_distribution_major_version | int in [7, 8]
+
+- name: Configure DNF type of upgrades.
+  lineinfile:
+    dest: '{{ update_conf_path }}'
+    regexp: '^upgrade_type = .+'
+    line: 'upgrade_type = {{ security_dnf_upgrade_type }}'
+  when:
+    - security_autoupdate_enabled
+    - ansible_distribution_major_version | int in [7, 8]
+    


### PR DESCRIPTION
Hi, I just add the option to set the "upgrade_type" parameter on /etc/dnf/automatic.conf file for RedHat-8 servers.

I'll be glad if you approve it, so I wont need to keep the post-config in a different place