### PR TITLE
Fix sshd config validation when Match statements are used on OpenSSH 7

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -10,7 +10,7 @@
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present
-    validate: 'sshd -T -f %s'
+    validate: 'sshd -T -C user=root -C host=localhost -C addr=localhost -f %s'
     mode: 0644
   with_items:
     - regexp: "^PasswordAuthentication"


### PR DESCRIPTION
I have a statement like this in my sshd_config on OpenSSH 7.9 (Debian Buster):

```
Match Group foobar
    PasswordAuthentication yes
    ChrootDirectory %h/ftp_access
    X11Forwarding no
    AllowTcpForwarding yes
    ForceCommand internal-sftp
```


This Ansible role was failing to execute with this error:

```
| msg: failed to validate: rc:255 error:'Match Group' in configuration but 'user' not in connection test specification.
```

I found the same issue in another Ansible role:

https://github.com/dev-sec/ansible-ssh-hardening/issues/188

and its associated PR fix:

https://github.com/dev-sec/ansible-ssh-hardening/pull/202

The same fix in your role seems to work for me, so here's a PR for it!