### PR TITLE
Issue 79 - Adds AllowUsers and AllowGroups to SSH Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ The port through which you'd like SSH to be accessible. The default is port 22, 
 
 Security settings for SSH authentication. It's best to leave these set to `"no"`, but there are times (especially during initial server configuration or when you don't have key-based authentication in place) when one or all may be safely set to `'yes'`. **NOTE: It is _very_ important that you quote the 'yes' or 'no' values. Failure to do so may lock you out of your server.**
 
+    security_ssh_allowed_users: []
+    # - alice
+    # - bob
+    # - charlie
+
+A list of users allowed to connect to the host over SSH.  If no user is defined in the list, the task will be skipped.
+
+    security_ssh_allowed_groups: []
+    # - admins
+    # - devs
+
+A list of groups allowed to connect to the host over SSH.  If no group is defined in the list, the task will be skipped.
+
     security_sshd_state: started
 
 The state of the SSH daemon. Typically this should remain `started`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ security_ssh_gss_api_authentication: "no"
 security_ssh_x11_forwarding: "no"
 security_sshd_state: started
 security_ssh_restart_handler_state: restarted
+security_ssh_allowed_users: []
+security_ssh_allowed_groups: []
 
 security_sudoers_passwordless: []
 security_sudoers_passworded: []

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -31,6 +31,30 @@
       line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
   notify: restart ssh
 
+- name: Add configured users allowed to connect over ssh
+  lineinfile:
+    dest: "{{ security_ssh_config_path }}"
+    regexp: '^AllowUsers'
+    line: "AllowUsers {{ security_ssh_allowed_users | join(' ') }}"
+    state: present
+    create: true
+    validate: 'sshd -T -f %s'
+    mode: 0644
+  when: security_ssh_allowed_users | length > 0
+  notify: restart ssh
+
+- name: Add configured groups allowed to connect over ssh
+  lineinfile:
+    dest: "{{ security_ssh_config_path }}"
+    regexp: '^AllowGroups'
+    line: "AllowGroups {{ security_ssh_allowed_groups | join(' ') }}"
+    state: present
+    create: true
+    validate: 'sshd -T -f %s'
+    mode: 0644
+  when: security_ssh_allowed_groups | length > 0
+  notify: restart ssh
+
 - name: Add configured user accounts to passwordless sudoers.
   lineinfile:
     dest: /etc/sudoers


### PR DESCRIPTION
2 vars and 2 tasks added to `tasks/ssh.yml`.  Allows for the configuration of AllowedUsers and AllowedGroups if so desired.  If no users or groups are defined in the `security_ssh_allowed_users` or `security_ssh_allowed_groups` vars, the task will be skipped.  Also updated the README to reflect this.