### PR TITLE
Issue 85/autoupdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ A list of users who should be added to the sudoers file so they can run any comm
 
 Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgrades` (Debian-based systems). System restarts will not happen automatically in any case, and automatic upgrades are no excuse for sloppy patch and package management, but automatic updates can be helpful as yet another security measure.
 
+    security_autoupdate_secpkgs_only: false
+Whether to configure security only related package updates or all updates.
+
     security_autoupdate_blacklist: []
 
 (Debian/Ubuntu only) A listing of packages that should not be automatically updated.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Whether to configure security only related package updates or all updates.
 
     security_autoupdate_blacklist: []
 
-(Debian/Ubuntu only) A listing of packages that should not be automatically updated.
+A listing of packages that should not be automatically updated.
 
     security_autoupdate_reboot: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ security_sudoers_passworded: []
 
 security_autoupdate_enabled: true
 security_autoupdate_blacklist: []
+security_autoupdate_secpkgs_only: false
 
 # Autoupdate mail settings used on Debian/Ubuntu only.
 security_autoupdate_reboot: "false"

--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -44,3 +44,14 @@
     - security_autoupdate_enabled
     - security_autoupdate_secpkgs_only
     - ansible_distribution_major_version | int in [7, 8]
+
+- name: Set automatic update blacklist.
+  lineinfile:
+    dest: '{{ update_conf_path }}'
+    insertafter: '[base]'
+    line: 'exclude = {{ security_autoupdate_blacklist | join(" ") }}'
+    mode: 0644
+  when:
+    - security_autoupdate_enabled
+    - security_autoupdate_blacklist
+    - ansible_distribution_major_version | int in [7, 8]

--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -24,7 +24,7 @@
     state: started
     enabled: true
 
-- name: Configure autoupdates.
+- name: Enable autoupdates.
   lineinfile:
     dest: '{{ update_conf_path }}'
     regexp: '^apply_updates = .+'
@@ -32,4 +32,15 @@
     mode: 0644
   when:
     - security_autoupdate_enabled
+    - ansible_distribution_major_version | int in [7, 8]
+
+- name: Set automatic update type to security updates only.
+  lineinfile:
+    dest: '{{ update_conf_path }}'
+    regexp: '^update_cmd = .+'
+    line: 'update_cmd = security'
+    mode: 0644
+  when:
+    - security_autoupdate_enabled
+    - security_autoupdate_secpkgs_only
     - ansible_distribution_major_version | int in [7, 8]

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -10,7 +10,9 @@ Unattended-Upgrade::MailOnlyOnError "true";
 
 Unattended-Upgrade::Allowed-Origins {
         "${distro_id} ${distro_codename}-security";
-//      "${distro_id} ${distro_codename}-updates";
+{% if not security_autoupdate_secpkgs_only %}
+        "${distro_id} ${distro_codename}-updates";
+{% endif %}
 };
 
 Unattended-Upgrade::Package-Blacklist{


### PR DESCRIPTION
Added a new var (security_autoupdate_secpkgs_only) that is defaulted to `false`.  This will configure RHEL based hosts and Debian based hosts to auto update all packages that are otherwise not in the blacklist.  If set to `true`, both RHEL based hosts and Debian based hosts will be configured to only auto update security related packages.

Tested against ubuntu locally by adding the following to molecule confige:
```
  - name: instance-ubuntu
    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
    command: ${MOLECULE_DOCKER_COMMAND:-""}
    volumes:
      - /sys/fs/cgroup:/sys/fs/cgroup:ro
    privileged: true
    pre_build_image: true
```