### PR TITLE
Add SELinux rules for new SSH port (RedHat)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,10 @@
 # SSH
 - include_tasks: ssh.yml
 
+# SELinux SSH Rules (RedHat)
+- include_tasks: sepolicy-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
 # Autoupdate
 - include_tasks: autoupdate-RedHat.yml
   when:

--- a/tasks/sepolicy-RedHat.yml
+++ b/tasks/sepolicy-RedHat.yml
@@ -1,0 +1,9 @@
+---
+- name: Check if SSH port is already allowed in SELinux (RedHat)
+  shell: semanage port -lC | grep {{ security_ssh_port }}            
+  register: allowed
+  ignore_errors: yes
+
+- name: Allow SSH to run on {{ security_ssh_port }} (RedHat)
+  command: semanage port -a -t ssh_port_t -p tcp {{ security_ssh_port }}
+  when: allowed.rc != 0


### PR DESCRIPTION
* Tested on Fedora 35
* It can be done in "natively" idempotence way, but it will require dependencies as community.general collection to use community.general.seport module
```
- name: Allow sshd to listen on {{ security_ssh_port }}
  community.general.seport:
    ports: {{ security_ssh_port }}
    proto: tcp
    setype: ssh_port_t
    state: present
```