### PR TITLE
add user regex: blank added to uniquely identify the user

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -58,7 +58,7 @@
 - name: Add configured user accounts to passwordless sudoers.
   lineinfile:
     dest: /etc/sudoers
-    regexp: '^{{ item }}'
+    regexp: '^{{ item }} '
     line: '{{ item }} ALL=(ALL) NOPASSWD: ALL'
     state: present
     validate: 'visudo -cf %s'
@@ -69,7 +69,7 @@
 - name: Add configured user accounts to passworded sudoers.
   lineinfile:
     dest: /etc/sudoers
-    regexp: '^{{ item }}'
+    regexp: '^{{ item }} '
     line: '{{ item }} ALL=(ALL) ALL'
     state: present
     validate: 'visudo -cf %s'


### PR DESCRIPTION
I want to add 2 users by using security_sudoers_passwordless or security_sudoers_passworded:
1. MXPicture
2. MXPictureAnsible

The /etc/sudoers file should look like this:
MXPicture ALL=(ALL) NOPASSWD: ALL
MXPictureAnsible ALL=(ALL) NOPASSWD: ALL

But it looks like this (after the second run):
MXPicture ALL=(ALL) NOPASSWD: ALL
MXPicture ALL=(ALL) NOPASSWD: ALL