### PR TITLE
update templates Debian unattended-upgrades

### DIFF
--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -8,9 +8,19 @@ Unattended-Upgrade::MailOnlyOnError "true";
 {% endif %}
 {% endif %}
 
+// below mostly works in Ubuntu based
 Unattended-Upgrade::Allowed-Origins {
         "${distro_id} ${distro_codename}-security";
+        "${distro_id}:${distro_codename}-security";
 //      "${distro_id} ${distro_codename}-updates";
+};
+
+//somehow below its working one for Debian based 
+Unattended-Upgrade::Origins-Pattern {
+        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
+//      "origin=Debian,codename=${distro_codename},label=Debian";
+//      "origin=Debian,codename=${distro_codename}-updates;
+//      "origin=Debian,codename=${distro_codename}-proposed-updates;
 };
 
 Unattended-Upgrade::Package-Blacklist{


### PR DESCRIPTION
Hi
Sorry, im wondering if its okay to update the template unattended-upgrades for Debian & Ubuntu based - which from what i tested this should no affect error for both platform

The unattended-upgrades in Debian will need below in order to work
```
Unattended-Upgrade::Origins-Pattern {
        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
};
```
while Ubuntu based still working with default one.

Many thanks for sharing this role playbook