### PR TITLE
Fix errors on RHEL9

### DIFF
--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -1,10 +1,10 @@
 ---
-- name: Set correct automatic update utility vars (RHEL 8).
+- name: Set correct automatic update utility vars (RHEL 8/9).
   set_fact:
     update_utility: dnf-automatic
     update_service: dnf-automatic-install.timer
     update_conf_path: /etc/dnf/automatic.conf
-  when: ansible_distribution_major_version | int == 8
+  when: ansible_distribution_major_version | int in [8, 9]
 
 - name: Set correct automatic update utility vars (RHEL <= 7).
   set_fact:
@@ -32,4 +32,4 @@
     mode: 0644
   when:
     - security_autoupdate_enabled
-    - ansible_distribution_major_version | int in [7, 8]
+    - ansible_distribution_major_version | int in [7, 8, 9]


### PR DESCRIPTION
Running against a Rocky Linux 9 (and presumably RHEL9) host gives the error:

`The task includes an option with an undefined variable. The error was: 'update_utility' is undefined`.

Add appropriate matching for EL9.