### PR TITLE
Use directory sudoers.d

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -57,7 +57,7 @@
 
 - name: Add configured user accounts to passwordless sudoers.
   lineinfile:
-    dest: /etc/sudoers
+    dest: /etc/sudoers.d/{{ item }}
     regexp: '^{{ item }}'
     line: '{{ item }} ALL=(ALL) NOPASSWD: ALL'
     state: present
@@ -68,7 +68,7 @@
 
 - name: Add configured user accounts to passworded sudoers.
   lineinfile:
-    dest: /etc/sudoers
+    dest: /etc/sudoers.d/{{ item }}
     regexp: '^{{ item }}'
     line: '{{ item }} ALL=(ALL) ALL'
     state: present


### PR DESCRIPTION
Hello, and thank you for your work putting together this very useful role.

Would you please consider this little edit, keeping modifications to the sudoers in the `sudoers.d` directory.
I understand that this would adhere to best practice.