### PR TITLE
Sudo tasks out of ssh.yml into own .yml file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,9 @@
 # SSH
 - include_tasks: ssh.yml
 
+# Sudoers
+- include_tasks: sudoers.yml
+
 # Autoupdate
 - include_tasks: autoupdate-RedHat.yml
   when:

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -54,25 +54,3 @@
     mode: 0644
   when: security_ssh_allowed_groups | length > 0
   notify: restart ssh
-
-- name: Add configured user accounts to passwordless sudoers.
-  lineinfile:
-    dest: /etc/sudoers
-    regexp: '^{{ item }}'
-    line: '{{ item }} ALL=(ALL) NOPASSWD: ALL'
-    state: present
-    validate: 'visudo -cf %s'
-    mode: 0440
-  with_items: "{{ security_sudoers_passwordless }}"
-  when: security_sudoers_passwordless | length > 0
-
-- name: Add configured user accounts to passworded sudoers.
-  lineinfile:
-    dest: /etc/sudoers
-    regexp: '^{{ item }}'
-    line: '{{ item }} ALL=(ALL) ALL'
-    state: present
-    validate: 'visudo -cf %s'
-    mode: 0440
-  with_items: "{{ security_sudoers_passworded }}"
-  when: security_sudoers_passworded | length > 0

--- a/tasks/sudoers.yml
+++ b/tasks/sudoers.yml
@@ -1,0 +1,22 @@
+---
+- name: Add configured user accounts to passwordless sudoers.
+  lineinfile:
+    dest: /etc/sudoers
+    regexp: '^{{ item }}'
+    line: '{{ item }} ALL=(ALL) NOPASSWD: ALL'
+    state: present
+    validate: 'visudo -cf %s'
+    mode: 0440
+  with_items: "{{ security_sudoers_passwordless }}"
+  when: security_sudoers_passwordless | length > 0
+
+- name: Add configured user accounts to passworded sudoers.
+  lineinfile:
+    dest: /etc/sudoers
+    regexp: '^{{ item }}'
+    line: '{{ item }} ALL=(ALL) ALL'
+    state: present
+    validate: 'visudo -cf %s'
+    mode: 0440
+  with_items: "{{ security_sudoers_passworded }}"
+  when: security_sudoers_passworded | length > 0


### PR DESCRIPTION
This just broke out the existing sudo security from the tasks/ssh.yml file into its own tasks/sudoers.yml file and updated the main.yml to include tasks pointing to the new file.