### PR TITLE
Fix: SSH regexp match commented out lines too

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -13,28 +13,28 @@
     validate: 'sshd -T -f %s'
     mode: 0644
   with_items:
-    - regexp: '^(\s+)?([#]+)?(\s+)?PasswordAuthentication'
+    - regexp: '^(#|)PasswordAuthentication'
       line: "PasswordAuthentication {{ security_ssh_password_authentication }}"
-    - regexp: '^(\s+)?([#]+)?(\s+)?PermitRootLogin'
+    - regexp: '^(#|)PermitRootLogin'
       line: "PermitRootLogin {{ security_ssh_permit_root_login }}"
-    - regexp: '^(\s+)?([#]+)?(\s+)?Port'
+    - regexp: '^(#|)Port'
       line: "Port {{ security_ssh_port }}"
-    - regexp: '^(\s+)?([#]+)?(\s+)?UseDNS'
+    - regexp: '^(#|)UseDNS'
       line: "UseDNS {{ security_ssh_usedns }}"
-    - regexp: '^(\s+)?([#]+)?(\s+)?PermitEmptyPasswords'
+    - regexp: '^(#|)PermitEmptyPasswords'
       line: "PermitEmptyPasswords {{ security_ssh_permit_empty_password }}"
-    - regexp: '^(\s+)?([#]+)?(\s+)?ChallengeResponseAuthentication'
+    - regexp: '^(#|)ChallengeResponseAuthentication'
       line: "ChallengeResponseAuthentication {{ security_ssh_challenge_response_auth }}"
-    - regexp: '^(\s+)?([#]+)?(\s+)?GSSAPIAuthentication'
+    - regexp: '^(#|)GSSAPIAuthentication'
       line: "GSSAPIAuthentication {{ security_ssh_gss_api_authentication }}"
-    - regexp: '^(\s+)?([#]+)?(\s+)?X11Forwarding'
+    - regexp: '^(#|)X11Forwarding'
       line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
   notify: restart ssh
 
 - name: Add configured users allowed to connect over ssh
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
-    regexp: '^(\s+)?([#]+)?(\s+)?AllowUsers'
+    regexp: '^(#|)AllowUsers'
     line: "AllowUsers {{ security_ssh_allowed_users | join(' ') }}"
     state: present
     create: true
@@ -46,7 +46,7 @@
 - name: Add configured groups allowed to connect over ssh
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
-    regexp: '^(\s+)?([#]+)?(\s+)?AllowGroups'
+    regexp: '^(#|)AllowGroups'
     line: "AllowGroups {{ security_ssh_allowed_groups | join(' ') }}"
     state: present
     create: true

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -13,28 +13,28 @@
     validate: 'sshd -T -f %s'
     mode: 0644
   with_items:
-    - regexp: "^PasswordAuthentication"
+    - regexp: '^(\s+)?([#]+)?(\s+)?PasswordAuthentication'
       line: "PasswordAuthentication {{ security_ssh_password_authentication }}"
-    - regexp: "^PermitRootLogin"
+    - regexp: '^(\s+)?([#]+)?(\s+)?PermitRootLogin'
       line: "PermitRootLogin {{ security_ssh_permit_root_login }}"
-    - regexp: "^Port"
+    - regexp: '^(\s+)?([#]+)?(\s+)?Port'
       line: "Port {{ security_ssh_port }}"
-    - regexp: "^UseDNS"
+    - regexp: '^(\s+)?([#]+)?(\s+)?UseDNS'
       line: "UseDNS {{ security_ssh_usedns }}"
-    - regexp: "^PermitEmptyPasswords"
+    - regexp: '^(\s+)?([#]+)?(\s+)?PermitEmptyPasswords'
       line: "PermitEmptyPasswords {{ security_ssh_permit_empty_password }}"
-    - regexp: "^ChallengeResponseAuthentication"
+    - regexp: '^(\s+)?([#]+)?(\s+)?ChallengeResponseAuthentication'
       line: "ChallengeResponseAuthentication {{ security_ssh_challenge_response_auth }}"
-    - regexp: "^GSSAPIAuthentication"
+    - regexp: '^(\s+)?([#]+)?(\s+)?GSSAPIAuthentication'
       line: "GSSAPIAuthentication {{ security_ssh_gss_api_authentication }}"
-    - regexp: "^X11Forwarding"
+    - regexp: '^(\s+)?([#]+)?(\s+)?X11Forwarding'
       line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
   notify: restart ssh
 
 - name: Add configured users allowed to connect over ssh
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
-    regexp: '^AllowUsers'
+    regexp: '^(\s+)?([#]+)?(\s+)?AllowUsers'
     line: "AllowUsers {{ security_ssh_allowed_users | join(' ') }}"
     state: present
     create: true
@@ -46,7 +46,7 @@
 - name: Add configured groups allowed to connect over ssh
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
-    regexp: '^AllowGroups'
+    regexp: '^(\s+)?([#]+)?(\s+)?AllowGroups'
     line: "AllowGroups {{ security_ssh_allowed_groups | join(' ') }}"
     state: present
     create: true

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -8,33 +8,43 @@
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
     regexp: "{{ item.regexp }}"
+    insertafter: "{{ item.insertafter }}"
     line: "{{ item.line }}"
     state: present
     validate: 'sshd -T -f %s'
     mode: 0644
   with_items:
-    - regexp: '^(#|)PasswordAuthentication'
+    - regexp: '^PasswordAuthentication'
+      insertafter: '^#PasswordAuthentication'
       line: "PasswordAuthentication {{ security_ssh_password_authentication }}"
-    - regexp: '^(#|)PermitRootLogin'
+    - regexp: '^PermitRootLogin'
+      insertafter: '^#PermitRootLogin'
       line: "PermitRootLogin {{ security_ssh_permit_root_login }}"
-    - regexp: '^(#|)Port'
+    - regexp: '^Port'
+      insertafter: '^#Port'
       line: "Port {{ security_ssh_port }}"
-    - regexp: '^(#|)UseDNS'
+    - regexp: '^UseDNS'
+      insertafter: '^#UseDNS'
       line: "UseDNS {{ security_ssh_usedns }}"
-    - regexp: '^(#|)PermitEmptyPasswords'
+    - regexp: '^PermitEmptyPasswords'
+      insertafter: '^#PermitEmptyPasswords'
       line: "PermitEmptyPasswords {{ security_ssh_permit_empty_password }}"
-    - regexp: '^(#|)ChallengeResponseAuthentication'
+    - regexp: '^ChallengeResponseAuthentication'
+      insertafter: '^#ChallengeResponseAuthentication'
       line: "ChallengeResponseAuthentication {{ security_ssh_challenge_response_auth }}"
-    - regexp: '^(#|)GSSAPIAuthentication'
+    - regexp: '^GSSAPIAuthentication'
+      insertafter: '^#GSSAPIAuthentication'
       line: "GSSAPIAuthentication {{ security_ssh_gss_api_authentication }}"
-    - regexp: '^(#|)X11Forwarding'
+    - regexp: '^X11Forwarding'
+      insertafter: '^#X11Forwarding'
       line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
   notify: restart ssh
 
 - name: Add configured users allowed to connect over ssh
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
-    regexp: '^(#|)AllowUsers'
+    regexp: '^AllowUsers'
+    insertafter: '^#AllowUsers'
     line: "AllowUsers {{ security_ssh_allowed_users | join(' ') }}"
     state: present
     create: true
@@ -46,7 +56,8 @@
 - name: Add configured groups allowed to connect over ssh
   lineinfile:
     dest: "{{ security_ssh_config_path }}"
-    regexp: '^(#|)AllowGroups'
+    regexp: '^AllowGroups'
+    insertafter: '^#AllowGroups'
     line: "AllowGroups {{ security_ssh_allowed_groups | join(' ') }}"
     state: present
     create: true


### PR DESCRIPTION
Fixes: https://github.com/geerlingguy/ansible-role-security/issues/66

I experienced this issue on a fresh installation of Raspberry Pi OS Lite (64-bit). The default config has the lines commented out and the role task was failing to modify the commented out lines.