### PR TITLE
Adds the ability to override PasswordAuthentication setting per user or per group

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ A list of users allowed to connect to the host over SSH.  If no user is defined 
 
 A list of groups allowed to connect to the host over SSH.  If no group is defined in the list, the task will be skipped.
 
+    security_ssh_password_authentication_allowed_users: []
+    # - alice
+    # - bob
+    # - charlie
+
+A list of users allowed to authenticate with passwords, even if `security_ssh_password_authentication` is globally set to `"no"`.  If no user is defined in the list, the task will be skipped.
+
+    security_ssh_password_authentication_allowed_groups: []
+    # - admins
+    # - dev
+
+A list of groups allowed to authenticate with passwords, even if `security_ssh_password_authentication` is globally set to `"no"`.  If no group is defined in the list, the task will be skipped.
+
     security_sshd_state: started
 
 The state of the SSH daemon. Typically this should remain `started`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ security_sshd_state: started
 security_ssh_restart_handler_state: restarted
 security_ssh_allowed_users: []
 security_ssh_allowed_groups: []
+security_ssh_password_authentication_allowed_users: []
+security_ssh_password_authentication_allowed_groups: []
 
 security_sudoers_passwordless: []
 security_sudoers_passworded: []

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -62,8 +62,8 @@
       Match User {{ security_ssh_password_authentication_allowed_users | join(',') }}
         PasswordAuthentication yes
       Match all
-    marker_begin: geerlingguy.security security_ssh_password_authentication_allowed_users
-    marker_end: geerlingguy.security security_ssh_password_authentication_allowed_users
+    marker_begin: BEGIN geerlingguy.security security_ssh_password_authentication_allowed_users
+    marker_end: END geerlingguy.security security_ssh_password_authentication_allowed_users
     state: present
     create: true
     validate: 'sshd -T -f %s'
@@ -78,8 +78,8 @@
       Match Group {{ security_ssh_password_authentication_allowed_groups | join(',') }}
         PasswordAuthentication yes
       Match all
-    marker_begin: geerlingguy.security security_ssh_password_authentication_allowed_groups
-    marker_end: geerlingguy.security security_ssh_password_authentication_allowed_groups
+    marker_begin: BEGIN geerlingguy.security security_ssh_password_authentication_allowed_groups
+    marker_end: END geerlingguy.security security_ssh_password_authentication_allowed_groups
     state: present
     create: true
     validate: 'sshd -T -f %s'

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -69,6 +69,7 @@
     validate: 'sshd -T -f %s'
     mode: 0644
   when: security_ssh_password_authentication_allowed_users | length > 0
+  notify: restart ssh
 
 - name: Add configured groups allowed to authenticate with passwords
   blockinfile:
@@ -84,6 +85,7 @@
     validate: 'sshd -T -f %s'
     mode: 0644
   when: security_ssh_password_authentication_allowed_groups | length > 0
+  notify: restart ssh
 
 - name: Add configured user accounts to passwordless sudoers.
   lineinfile:

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -55,6 +55,36 @@
   when: security_ssh_allowed_groups | length > 0
   notify: restart ssh
 
+- name: Add configured users allowed to authenticate with passwords
+  blockinfile:
+    dest: "{{ security_ssh_config_path }}"
+    block: |
+      Match User {{ security_ssh_password_authentication_allowed_users | join(',') }}
+        PasswordAuthentication yes
+      Match all
+    marker_begin: geerlingguy.security security_ssh_password_authentication_allowed_users
+    marker_end: geerlingguy.security security_ssh_password_authentication_allowed_users
+    state: present
+    create: true
+    validate: 'sshd -T -f %s'
+    mode: 0644
+  when: security_ssh_password_authentication_allowed_users | length > 0
+
+- name: Add configured groups allowed to authenticate with passwords
+  blockinfile:
+    dest: "{{ security_ssh_config_path }}"
+    block: |
+      Match Group {{ security_ssh_password_authentication_allowed_groups | join(',') }}
+        PasswordAuthentication yes
+      Match all
+    marker_begin: geerlingguy.security security_ssh_password_authentication_allowed_groups
+    marker_end: geerlingguy.security security_ssh_password_authentication_allowed_groups
+    state: present
+    create: true
+    validate: 'sshd -T -f %s'
+    mode: 0644
+  when: security_ssh_password_authentication_allowed_groups | length > 0
+
 - name: Add configured user accounts to passwordless sudoers.
   lineinfile:
     dest: /etc/sudoers


### PR DESCRIPTION
Hi,

we have the usecase that we generally don't allow PasswordAuthentication to our servers, but now have to allow it for some IoT devices for SFTP access.

I noticed that this role does not allow one to configure exceptions or overrides for this setting, so I implemented it here.

There are some things I would like to hear your thoughts on before a merge:

- The blockinfile "dest" parameter is an [outdated alias](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/blockinfile_module.html#parameter-path) for "path" -  same as with lineinfile. I used "dest" anyway to keep it the same as all the other tasks, but I could change this everywhere?
- I didn't use FQCN because I saw the other tasks don't use it either
- I can see the problem that when one of the "security_ssh_ ... \_users" or "security_ssh_ ... _groups" variables is cleared / set to an empty array, the tasks for configuring these options are just skipped, but the expected (and secure) behavior would probably be to clear these lists/settings in the sshd_config rather than do nothing and keep whatever the previous state was? I did it like this though to have the same behavior as the existing `security_ssh_allowed_users` and `security_ssh_allowed_groups` tasks from #84 
- `Match all` statement to close a Match block is something we've been using for a long time, and according to [this StackExchange post](https://unix.stackexchange.com/a/303982) it is supported in OpenSSH 6.5p1 and up - that's enough right? We don't have to support every mega-old version of OpenSSH? I don't know about busybox / dropbear and other SSH servers
- The Match statements are exceptions/overrides to the general config and must come after the global `PasswordAuthentication` setting in the sshd_config to work. This is why I put the tasks after the other ssh-config tasks so the blocks are inserted after. [The default value for blockinfile parameter "insertafter" is "EOL"](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/blockinfile_module.html#parameter-insertafter) so I they should always be put after the global "PassworthAuthentication yes|no" setting because the "Update SSH configuration to be more secure" tasks is not optional / skippable it is ensured that the global "PassworthAuthentication yes|no" setting has been configured already, earlier in the file
- We could use this chance to implement a more sophisticated, general-purpose override config variable instead such as:
  ```yaml
  security_ssh_overrides_groups: []
  
  security_ssh_overrides_users:
    - users: [charlie]
      config: |
        PasswordAuthentication yes
    - users: [bob, alice]
      config: |
        X11Forwarding yes
  ```
  or
  ```yaml
  security_ssh_overrides_groups: []
  
  security_ssh_overrides_users:
    - users:
        - charlie
      overrides:
        - PasswordAuthentication yes
    - users:
        - bob
        - alice
      overrides:
        - X11Forwarding yes
  ```
This would allow users of the role to configure security-exceptions (or any other setting) for anything they want, not just PasswordAuthentication. However you will have to decide whether the more complex data structure required for this fits with the role which is otherwise very simple to configure. These variables would of course be optional though. IF this is something you'd want to have in the role, the order and therefore precedence of `security_ssh_overrides_users` vs `security_ssh_overrides_groups` has to be ensured (either task can't just be skipped) because any arbitrary setting may be configured one way for a group a user is a member of and also on the user directly. Curently the order of the `Match User` and `Match Group` blocks is not deterministic because it doesn't matter as long as it's the same setting applied to both. The `... _users` variable is processed first, but if someone configures only the `... _groups` initially, runs the role and then later adds a configuration for `... _users`, the `Match User` block would be inserted after the `Match Group` block which could result in unpredictable outcomes *IF* arbitrary overrides were to be supported.

What do you think?