### PR TITLE
Adding logpath in case the default doesn't exist.

### DIFF
--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -2,3 +2,4 @@
 enabled = true
 port    = {{ security_ssh_port }}
 filter  = sshd
+logpath = /var/log/fail2ban.log


### PR DESCRIPTION
Not sure where it looks by default, but when using this role in `lsiobase/ubuntu:focal` I got the error:
```
TASK [geerlingguy.security : Ensure fail2ban is running and enabled on boot.] ***********************
fatal: [devshop.local.computer]: FAILED! => changed=false 
  msg: |-
    2023-03-18 17:19:59,601 fail2ban                [3843]: ERROR   Failed during configuration: Have not found any log file for sshd jail
```


I don't really know if this is ideal, but the file /var/log/fail2ban.log exists already.