### PR TITLE
fix(rhel 9): autoupdate with dnf-automatic

### DIFF
--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -1,10 +1,12 @@
 ---
-- name: Set correct automatic update utility vars (RHEL 8).
+- name: Set correct automatic update utility vars (RHEL 8 & 9).
   set_fact:
     update_utility: dnf-automatic
     update_service: dnf-automatic-install.timer
     update_conf_path: /etc/dnf/automatic.conf
-  when: ansible_distribution_major_version | int == 8
+  when: >
+    ansible_distribution_major_version | int == 8
+    or ansible_distribution_major_version | int == 9
 
 - name: Set correct automatic update utility vars (RHEL <= 7).
   set_fact:


### PR DESCRIPTION
Hey, thanks for this ansible role.

I found an issue with RHEL 9 distros, where the fact `update_utility` would not be set.

Autoupdate with dnf should work the same way on RHEL 9 as on RHEL 8.
<https://access.redhat.com/documentation/de-de/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/assembly_automating-software-updates-in-rhel-9_managing-software-with-the-dnf>

So we could just extend the condition with a check for RHEL 9.