### PR TITLE
fix: use systemd backend for fail2ban for Debian 12 and higher

### DIFF
--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -12,13 +12,26 @@
     state: present
   when: ansible_os_family == 'Debian'
 
-- name: Copy fail2ban custom configuration file into place.
+- name: Copy jail custom configuration file into place.
   template:
     src: "{{ security_fail2ban_custom_configuration_template }}"
     dest: /etc/fail2ban/jail.local
     owner: root
     group: root
     mode: 0644
+  notify:
+   - reload fail2ban
+
+- name: Copy fail2ban custom configuration file into place.
+  template:
+    src: fail2ban.local.j2
+    dest: /etc/fail2ban/fail2ban.local
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_major_version | int >= 12
   notify:
    - reload fail2ban
 

--- a/templates/fail2ban.local.j2
+++ b/templates/fail2ban.local.j2
@@ -1,0 +1,2 @@
+[Definition]
+logtarget = SYSTEMD-JOURNAL

--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -1,10 +1,7 @@
-{% if ansible_distribution_major_version | int >= 12 %}
-[DEFAULT]
-backend = systemd
-logtarget = SYSTEMD-JOURNAL
-
-{% endif %}
 [sshd]
 enabled = true
 port    = {{ security_ssh_port }}
 filter  = sshd
+{% if ansible_os_family == 'Debian' and ansible_distribution_major_version | int >= 12 %}
+backend = systemd
+{% endif %}

--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -1,3 +1,9 @@
+{% if ansible_distribution_major_version | int >= 12 %}
+[DEFAULT]
+backend = systemd
+logtarget = SYSTEMD-JOURNAL
+
+{% endif %}
 [sshd]
 enabled = true
 port    = {{ security_ssh_port }}


### PR DESCRIPTION
Fail2ban does not start on some debian/ubuntu systems because of /var/log/auth.log file does not exists.

Since Debian 12, the sylog, auth.log has been replaced by Journalctl. This change is the end of a change from traditional log files to Systemd-Journald-Daemons, which started with Debian 8 (Jessie).

References
#https://github.com/fail2ban/fail2ban/issues/3292
Issue #https://github.com/geerlingguy/ansible-role-security/issues/121

