### PR TITLE
Add option to disable ssh hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ No special requirements for Debian/Ubuntu systems.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+    security_ssh_enabled: true 
+This setting determines whether to enable or disable SSH hardening. When set to true, SSH hardening measures are applied, which include disabling root login, disabling password authentication, and more. These measures are designed to enhance the security of your SSH server. However, they should not be used as a substitute for a comprehensive security strategy.
+
     security_ssh_port: 22
 
 The port through which you'd like SSH to be accessible. The default is port 22, but if you're operating a server on the open internet, and have no firewall blocking access to port 22, you'll quickly find that thousands of login attempts per day are not uncommon. You can change the port to a nonstandard port (e.g. 2849) if you want to avoid these thousands of automated penetration attempts.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+security_ssh_enabled: true
 security_ssh_port: 22
 security_ssh_password_authentication: "no"
 security_ssh_permit_root_login: "no"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 
 # SSH
 - include_tasks: ssh.yml
-
+  when: security_ssh_enabled | bool
 # Autoupdate
 - include_tasks: autoupdate-RedHat.yml
   when:


### PR DESCRIPTION
I propose the introduction of an option to disable SSH hardening for this role. Similar to the existing `security_autoupdate_enabled` and `security_fail2ban_enabled` options, this would provide flexibility to use an alternative role. 

