### PR TITLE
Remove automatic cloud-init option allowing PasswordAuthentication

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -31,6 +31,15 @@
       line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
   notify: restart ssh
 
+- name: Ensure cloud-init conf does not still allow passwords anyway.
+  lineinfile:
+    dest: "{{ security_ssh_cloudinit_config_path }}"
+    regexp: "^PasswordAuthentication"
+    state: absent
+    validate: 'sshd -T -f %s'
+    mode: 0600
+  notify: restart ssh
+
 - name: Add configured users allowed to connect over ssh
   lineinfile:
     dest: "{{ security_ssh_config_path }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,4 @@
 ---
 security_ssh_config_path: /etc/ssh/sshd_config
+security_ssh_cloudinit_config_path: /etc/ssh/sshd_config.d/50-cloud-init.conf
 security_sshd_name: ssh


### PR DESCRIPTION
fixes #117 

A bug in the Ubuntu 22.04 installer generates a cloud-init config file which overwrites the `PasswordAuthentication` option set by this Ansible role, thus ignoring any attempt to disable it. This commit ensures that line in that file doesn't exist anymore. 