### PR TITLE
Expose ssh config mode through variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The port through which you'd like SSH to be accessible. The default is port 22, 
     security_ssh_challenge_response_auth: "no"
     security_ssh_gss_api_authentication: "no"
     security_ssh_x11_forwarding: "no"
+    security_ssh_config_mode: 0644
 
 Security settings for SSH authentication. It's best to leave these set to `"no"`, but there are times (especially during initial server configuration or when you don't have key-based authentication in place) when one or all may be safely set to `'yes'`. **NOTE: It is _very_ important that you quote the 'yes' or 'no' values. Failure to do so may lock you out of your server.**
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ security_sshd_state: started
 security_ssh_restart_handler_state: restarted
 security_ssh_allowed_users: []
 security_ssh_allowed_groups: []
+security_ssh_config_mode: 0644
 
 security_sudoers_passwordless: []
 security_sudoers_passworded: []

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -39,7 +39,7 @@
     state: present
     create: true
     validate: 'sshd -T -f %s'
-    mode: 0644
+    mode: '{{ security_ssh_config_mode }}'
   when: security_ssh_allowed_users | length > 0
   notify: restart ssh
 


### PR DESCRIPTION
I had the issue, that another tool was used on a server, that by default changed the SSH config files mode to even more lock down who can see its contents. Unfortunately this would introduce a race between my playbook and the other tool.

When you are able to set the file mode, you can make the your playbook idempotent in such a case.