### PR TITLE
Additional list for Unattended-Upgrade::Allowed-Origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgra
 
 (Debian/Ubuntu only) A listing of packages that should not be automatically updated.
 
+    security_autoupdate_additional_origins: []
+    # - "${distro_id}ESM:${distro_codename}-infra-security"
+    # - "Docker:${distro_codename}"
+
+(Debian/Ubuntu only) A listing of origins to reference.
+
     security_autoupdate_reboot: false
 
 (Debian/Ubuntu only) Whether to reboot when needed during unattended upgrades.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ security_sudoers_passworded: []
 
 security_autoupdate_enabled: true
 security_autoupdate_blacklist: []
+security_autoupdate_additional_origins: []
 
 # Autoupdate mail settings used on Debian/Ubuntu only.
 security_autoupdate_reboot: "false"

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -11,6 +11,9 @@ Unattended-Upgrade::MailOnlyOnError "true";
 Unattended-Upgrade::Allowed-Origins {
         "${distro_id} ${distro_codename}-security";
 //      "${distro_id} ${distro_codename}-updates";
+{% for origin in security_autoupdate_additional_origins %}
+        "{{ origin }}";
+{% endfor %}
 };
 
 Unattended-Upgrade::Package-Blacklist{


### PR DESCRIPTION
Added the `security_autoupdate_additional_origins` list as a variable.
The default value is an empty list and does not change the previous behavior.

This allows for automatic updates of packages obtained from the ESM or from third-party (e.g. Docker) repositories.
It is important to use the latest versions of these packages for security reasons.