### PR TITLE
Correctly install security updates on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,9 @@ Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgra
 (Debian/Ubuntu only) A listing of packages that should not be automatically updated.
 
     security_autoupdate_additional_origins: []
-    # - "${distro_id}ESM:${distro_codename}-infra-security"
-    # - "Docker:${distro_codename}"
+    # - "origin=Docker,archive=${distro_codename}"
 
-(Debian/Ubuntu only) A listing of origins to reference. Debian's "Debian-Security" and Ubuntu's "${distro_codename}-security" origins are enabled by default.
+(Debian/Ubuntu only) A listing of additional origins to automatically update.
 
     security_autoupdate_reboot: false
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgra
     # - "${distro_id}ESM:${distro_codename}-infra-security"
     # - "Docker:${distro_codename}"
 
-(Debian/Ubuntu only) A listing of origins to reference.
+(Debian/Ubuntu only) A listing of origins to reference. Debian's "Debian-Security" and Ubuntu's "${distro_codename}-security" origins are enabled by default.
 
     security_autoupdate_reboot: false
 

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -9,8 +9,11 @@ Unattended-Upgrade::MailOnlyOnError "true";
 {% endif %}
 
 Unattended-Upgrade::Allowed-Origins {
+{% if ansible_distribution == 'Debian' %}
+        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security"
+{% else %}
         "${distro_id} ${distro_codename}-security";
-//      "${distro_id} ${distro_codename}-updates";
+{% endif %}
 {% for origin in security_autoupdate_additional_origins %}
         "{{ origin }}";
 {% endfor %}

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -8,19 +8,26 @@ Unattended-Upgrade::MailOnlyOnError "true";
 {% endif %}
 {% endif %}
 
-Unattended-Upgrade::Allowed-Origins {
-{% if ansible_distribution == 'Debian' %}
-        "${distro_id} stable-security"
-{% else %}
-        "${distro_id} ${distro_codename}-security";
-{% endif %}
+Unattended-Upgrade::Origins-Pattern {
+    // Debian security repositories
+    "origin=Debian,codename=${distro_codename},label=Debian-Security";
+    "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
+
+    // Ubuntu security repository
+    "origin=Ubuntu,archive=${distro_codename}-security"
+
+    // Ubuntu ESM repositories
+    "origin=${distro_id}ESMApps,archive=${distro_codename}-apps-security";
+    "origin=${distro_id}ESM,archive=${distro_codename}-infra-security";
+
+    // Custom repositories
 {% for origin in security_autoupdate_additional_origins %}
-        "{{ origin }}";
+    "{{ origin }}";
 {% endfor %}
-};
+}
 
 Unattended-Upgrade::Package-Blacklist{
 {% for package in security_autoupdate_blacklist %}
-      "{{package}}";
+    "{{package}}";
 {% endfor %}
 }

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -10,7 +10,7 @@ Unattended-Upgrade::MailOnlyOnError "true";
 
 Unattended-Upgrade::Allowed-Origins {
 {% if ansible_distribution == 'Debian' %}
-        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security"
+        "${distro_id} stable-security"
 {% else %}
         "${distro_id} ${distro_codename}-security";
 {% endif %}


### PR DESCRIPTION
Currently, whilst Debian is advertised as supported, the `unattended-upgrades` configuration doesn't actually install security updates, which could leave users with vulnerable servers, even though they've installed a package designed to install security updates automatically.

This PR updates to using the `Origins-Pattern` configuration, and correctly adds the origins for both Ubuntu **and Debian**'s security repositories.

I would have gone through responsible-disclosure channels, as this has severe security ramifications with this change, however this is a very public issue already, but hasn't been resolved:

- https://github.com/geerlingguy/ansible-role-security/pull/81
- https://github.com/geerlingguy/ansible-role-security/pull/91
- https://github.com/geerlingguy/ansible-role-security/issues/74
- https://github.com/geerlingguy/ansible-role-security/issues/57
- https://github.com/geerlingguy/ansible-role-security/issues/32

#126 is a great start, however the default configuration should still install security updates, as mentioned in the README.
