### PR TITLE
Fix sshd handlers for Debian 12.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: reload systemd
+  systemd_service:
+    daemon_reload: true
+
 - name: restart ssh
   service:
     name: "{{ security_sshd_name }}"

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -29,7 +29,9 @@
       line: "GSSAPIAuthentication {{ security_ssh_gss_api_authentication }}"
     - regexp: "^X11Forwarding"
       line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
-  notify: restart ssh
+  notify:
+    - reload systemd
+    - restart ssh
 
 - name: Add configured users allowed to connect over ssh
   lineinfile:


### PR DESCRIPTION
Debian 12, Ubuntu 22 and above need to re-run systemd generators to pull the updated sshd port config.

Just changing sshd_config has no effect, sshd still listens on default port 22.

In this PR I add an additional handler for Debian that simply runs `systemctl daemon-reload`. This forces systemd to rerun its generators.

https://discourse.ubuntu.com/t/sshd-now-uses-socket-based-activation-ubuntu-22-10-and-later/30189/14