### PR TITLE
Add option to enable TCP port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The port through which you'd like SSH to be accessible. The default is port 22, 
     security_ssh_challenge_response_auth: "no"
     security_ssh_gss_api_authentication: "no"
     security_ssh_x11_forwarding: "no"
+    security_ssh_allow_tcp_forwarding: "no"
+    security_ssh_gateway_ports: "no"
 
 Security settings for SSH authentication. It's best to leave these set to `"no"`, but there are times (especially during initial server configuration or when you don't have key-based authentication in place) when one or all may be safely set to `'yes'`. **NOTE: It is _very_ important that you quote the 'yes' or 'no' values. Failure to do so may lock you out of your server.**
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ security_sshd_state: started
 security_ssh_restart_handler_state: restarted
 security_ssh_allowed_users: []
 security_ssh_allowed_groups: []
+security_ssh_allow_tcp_forwarding: "no"
+security_ssh_gateway_ports: "no"
 
 security_sudoers_passwordless: []
 security_sudoers_passworded: []

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -29,6 +29,10 @@
       line: "GSSAPIAuthentication {{ security_ssh_gss_api_authentication }}"
     - regexp: "^X11Forwarding"
       line: "X11Forwarding {{ security_ssh_x11_forwarding }}"
+    - regexp: "^AllowTcpForwarding"
+      line: "AllowTcpForwarding {{ security_ssh_allow_tcp_forwarding }}"
+    - regexp: "^GatewayPorts"
+      line: "GatewayPorts {{ security_ssh_gateway_ports }}"
   notify: restart ssh
 
 - name: Add configured users allowed to connect over ssh


### PR DESCRIPTION
Add option to enable TCP port forwarding - by default tcp forwarding is enabled, but without gateway ports