### PR TITLE
Fix fail2ban logtarget for systemd

### DIFF
--- a/templates/fail2ban.local.j2
+++ b/templates/fail2ban.local.j2
@@ -1,2 +1,2 @@
 [Definition]
-logtarget = SYSTEMD-JOURNAL
+logtarget = SYSOUT


### PR DESCRIPTION
Fix logtarget when running fail2ban as systemd service.

It should actually be `SYSOUT` according to [this issue](https://github.com/fail2ban/fail2ban/issues/2227#issuecomment-421971353).