### PR TITLE
fix: Add missing semicolon

### DIFF
--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -14,7 +14,7 @@ Unattended-Upgrade::Origins-Pattern {
     "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
 
     // Ubuntu security repository
-    "origin=Ubuntu,archive=${distro_codename}-security"
+    "origin=Ubuntu,archive=${distro_codename}-security";
 
     // Ubuntu ESM repositories
     "origin=${distro_id}ESMApps,archive=${distro_codename}-apps-security";


### PR DESCRIPTION
The missing semicolon results into a broken value as origin pattern. Therefore updates was not applied.


Compare it with apt-config dump or run a dry-run where security updates are pending.

apt-config dump:

```
Unattended-Upgrade::Origins-Pattern "";
Unattended-Upgrade::Origins-Pattern:: "origin=Debian,codename=${distro_codename},label=Debian-Security";
Unattended-Upgrade::Origins-Pattern:: "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
Unattended-Upgrade::Origins-Pattern::origin%3dUbuntu,archive%3d${distro_codename}-security "origin=${distro_id}ESMApps,archive=${distro_codename}-apps-security";
Unattended-Upgrade::Origins-Pattern:: "origin=${distro_id}ESM,archive=${distro_codename}-infra-security";
```

vs.

```
Unattended-Upgrade::Origins-Pattern "";
Unattended-Upgrade::Origins-Pattern:: "origin=Debian,codename=${distro_codename},label=Debian-Security";
Unattended-Upgrade::Origins-Pattern:: "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
Unattended-Upgrade::Origins-Pattern:: "origin=${distro_id},archive=${distro_codename}";
Unattended-Upgrade::Origins-Pattern:: "origin=Ubuntu,archive=${distro_codename}-security";
Unattended-Upgrade::Origins-Pattern:: "origin=${distro_id}ESMApps,archive=${distro_codename}-apps-security";
```
