### PR TITLE
change lookup of ansible_ facts, to ensure they work after deprecation

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,7 +8,7 @@
       package:
         update_cache: true
         cache_valid_time: 600
-      when: ansible_facts.os_family == 'Debian'
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Ensure build dependencies are installed (RedHat).
       package:
@@ -16,13 +16,13 @@
           - openssh-server
           - openssh-clients
         state: present
-      when: ansible_facts.os_family == 'RedHat'
+      when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Ensure build dependencies are installed (Fedora).
       package:
         name: procps
         state: present
-      when: ansible_facts.distribution == 'Fedora'
+      when: ansible_facts['distribution'] == 'Fedora'
 
     - name: Ensure build dependencies are installed (Debian).
       package:
@@ -30,7 +30,7 @@
           - openssh-server
           - openssh-client
         state: present
-      when: ansible_facts.os_family == 'Debian'
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Ensure auth.log file is present.
       copy:
@@ -38,7 +38,7 @@
         content: ""
         force: false
         mode: 0644
-      when: ansible_facts.distribution == 'Debian'
+      when: ansible_facts['distribution'] == 'Debian'
 
   roles:
     - role: geerlingguy.security

--- a/tasks/autoupdate-RedHat.yml
+++ b/tasks/autoupdate-RedHat.yml
@@ -4,14 +4,14 @@
     update_utility: dnf-automatic
     update_service: dnf-automatic-install.timer
     update_conf_path: /etc/dnf/automatic.conf
-  when: ansible_facts.distribution_major_version | int >= 8
+  when: ansible_facts['distribution_major_version'] | int >= 8
 
 - name: Set correct automatic update utility vars (RHEL <= 7).
   set_fact:
     update_utility: yum-cron
     update_service: yum-cron
     update_conf_path: /etc/yum/yum-cron.conf
-  when: ansible_facts.distribution_major_version | int <= 7
+  when: ansible_facts['distribution_major_version'] | int <= 7
 
 - name: Install automatic update utility.
   package:
@@ -32,4 +32,4 @@
     mode: 0644
   when:
     - security_autoupdate_enabled
-    - ansible_facts.distribution_major_version | int in [7, 8]
+    - ansible_facts['distribution_major_version'] | int in [7, 8]

--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -4,13 +4,13 @@
     name: fail2ban
     state: present
     enablerepo: epel
-  when: ansible_facts.os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Install fail2ban (Debian).
   package:
     name: fail2ban
     state: present
-  when: ansible_facts.os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Copy jail custom configuration file into place.
   template:
@@ -30,8 +30,8 @@
     group: root
     mode: 0644
   when:
-    - ansible_facts.os_family == 'Debian'
-    - ansible_facts.distribution_major_version | int >= 12
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution_major_version'] | int >= 12
   notify:
     - reload fail2ban
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include OS-specific variables.
-  include_vars: "{{ ansible_facts.os_family }}.yml"
+  include_vars: "{{ ansible_facts['os_family'] }}.yml"
 
 # Fail2Ban
 - include_tasks: fail2ban.yml
@@ -12,10 +12,10 @@
 # Autoupdate
 - include_tasks: autoupdate-RedHat.yml
   when:
-    - ansible_facts.os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
     - security_autoupdate_enabled | bool
 
 - include_tasks: autoupdate-Debian.yml
   when:
-    - ansible_facts.os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
     - security_autoupdate_enabled | bool

--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -2,6 +2,6 @@
 enabled = true
 port    = {{ security_ssh_port }}
 filter  = sshd
-{% if ansible_facts.os_family == 'Debian' and ansible_facts.distribution_major_version | int >= 12 %}
+{% if ansible_facts['os_family'] == 'Debian' and ansible_facts['distribution_major_version'] | int >= 12 %}
 backend = systemd
 {% endif %}


### PR DESCRIPTION
This PR fixes the following deprecation warning:

> TASK [geerlingguy.security : Include OS-specific variables.] ***********************************************************************************************************
> [WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
> [DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
> Origin: /home/user/.ansible/roles/geerlingguy.security/tasks/main.yml:3:17
> 
> 1 ---
> 2 - name: Include OS-specific variables.
> 3   include_vars: "{{ ansible_os_family }}.yml"
>                   ^ column 17
> 
> Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.