### PR TITLE
fix: add missing semicolon to make Ubuntu unattended updates work again

### DIFF
--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -14,7 +14,7 @@ Unattended-Upgrade::Origins-Pattern {
     "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
 
     // Ubuntu security repository
-    "origin=Ubuntu,archive=${distro_codename}-security"
+    "origin=Ubuntu,archive=${distro_codename}-security";
 
     // Ubuntu ESM repositories
     "origin=${distro_id}ESMApps,archive=${distro_codename}-apps-security";


### PR DESCRIPTION
Adding the semicolon made unattended security upgrades work again on Ubuntu :slightly_smiling_face: 

Only tested on Ubuntu Noble (24.04), not Debian.