### PR TITLE
allow custom configuration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,10 @@ The name of the template file used to generate `fail2ban`'s configuration.
 
 The name of the template file used to generate `fail2ban`'s jail file.
 
-    security_fail2ban_custom_configuration_template: "DEPRECATED"
+    security_fail2ban_custom_configuration_template: "jail.local.j2"
 
-The name of the template file used to generate `fail2ban`'s configuration.
-This variable is deprecated and should no longer be used.
-Instead, use `security_fail2ban_configuration_template` to specify a custom configuration template.
+The name of the template file previously used to generate `fail2ban`'s jail configuration. This variable is deprecated and should no longer be used.
+Instead, use `security_fail2ban_jail_template` to specify a custom jail configuration template.
 Backwards compatibility is maintained for `security_fail2ban_custom_configuration_template`, but it will be removed in a future release.
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 
 That being said, this role performs some basic security configuration on RedHat and Debian-based linux systems. It attempts to:
 
-  - Install software to monitor bad SSH access (fail2ban)
-  - Configure SSH to be more secure (disabling root login, requiring key-based authentication, and allowing a custom SSH port to be set)
-  - Set up automatic updates (if configured to do so)
+- Install software to monitor bad SSH access (fail2ban)
+- Configure SSH to be more secure (disabling root login, requiring key-based authentication, and allowing a custom SSH port to be set)
+- Set up automatic updates (if configured to do so)
 
 There are a few other things you may or may not want to do (which are not included in this role) to make sure your servers are more secure, like:
 
-  - Use logwatch or a centralized logging server to analyze and monitor log files
-  - Securely configure user accounts and SSH keys (this role assumes you're not using password authentication or logging in as root)
-  - Have a well-configured firewall (check out the `geerlingguy.firewall` role on Ansible Galaxy for a flexible example)
+- Use logwatch or a centralized logging server to analyze and monitor log files
+- Securely configure user accounts and SSH keys (this role assumes you're not using password authentication or logging in as root)
+- Have a well-configured firewall (check out the `geerlingguy.firewall` role on Ansible Galaxy for a flexible example)
 
-Again: Your servers' security is *your* responsibility.
+Again: Your servers' security is _your_ responsibility.
 
 ## Requirements
 
@@ -49,13 +49,13 @@ Security settings for SSH authentication. It's best to leave these set to `"no"`
     # - bob
     # - charlie
 
-A list of users allowed to connect to the host over SSH.  If no user is defined in the list, the task will be skipped.
+A list of users allowed to connect to the host over SSH. If no user is defined in the list, the task will be skipped.
 
     security_ssh_allowed_groups: []
     # - admins
     # - devs
 
-A list of groups allowed to connect to the host over SSH.  If no group is defined in the list, the task will be skipped.
+A list of groups allowed to connect to the host over SSH. If no group is defined in the list, the task will be skipped.
 
     security_sshd_state: started
 
@@ -100,9 +100,20 @@ Whether to install/enable `yum-cron` (RedHat-based systems) or `unattended-upgra
 
 Whether to install/enable `fail2ban`. You might not want to use fail2ban if you're already using some other service for login and intrusion detection (e.g. [ConfigServer](http://configserver.com/cp/csf.html)).
 
-    security_fail2ban_custom_configuration_template: "jail.local.j2"
+    security_fail2ban_configuration_template: "fail2ban.local.j2"
 
 The name of the template file used to generate `fail2ban`'s configuration.
+
+    security_fail2ban_jail_template: "jail.local.j2"
+
+The name of the template file used to generate `fail2ban`'s jail file.
+
+    security_fail2ban_custom_configuration_template: "DEPRECATED"
+
+The name of the template file used to generate `fail2ban`'s configuration.
+This variable is deprecated and should no longer be used.
+Instead, use `security_fail2ban_configuration_template` to specify a custom configuration template.
+Backwards compatibility is maintained for `security_fail2ban_custom_configuration_template`, but it will be removed in a future release.
 
 ## Dependencies
 
@@ -116,7 +127,7 @@ None.
       roles:
         - geerlingguy.security
 
-*Inside `vars/main.yml`*:
+_Inside `vars/main.yml`_:
 
     security_sudoers_passworded:
       - johndoe

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,8 @@ security_autoupdate_mail_to: ""
 security_autoupdate_mail_on_error: true
 
 security_fail2ban_enabled: true
-security_fail2ban_custom_configuration_template: "jail.local.j2"
+security_fail2ban_jail_template: "jail.local.j2"
+security_fail2ban_configuration_template: "fail2ban.local.j2"
+
+# Deprecated variable, please dont't use it anymore:
+# security_fail2ban_custom_configuration_template: "jail.local.j2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,5 +29,5 @@ security_fail2ban_enabled: true
 security_fail2ban_jail_template: "jail.local.j2"
 security_fail2ban_configuration_template: "fail2ban.local.j2"
 
-# Deprecated variable, please dont't use it anymore:
+# Deprecated variable, please don't use it anymore:
 # security_fail2ban_custom_configuration_template: "jail.local.j2"

--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -12,9 +12,28 @@
     state: present
   when: ansible_facts.os_family == 'Debian'
 
-- name: Copy jail custom configuration file into place.
+- name: Assert for deprecated variable
+  assert:
+    quiet: true
+    that:
+      - security_fail2ban_custom_configuration_template is not defined
+    fail_msg: |
+      [DEPRECATION WARNING]: security_fail2ban_custom_configuration_template is deprecated
+      Origin: {{ role_path }}
+
+      Use `security_fail2ban_jail_template` instead.
+  ignore_errors: true
+  register: deprecated_variable
+
+- name: Set value of deprecated_variable into correct variable
+  set_fact:
+    security_fail2ban_jail_template: "{{ security_fail2ban_custom_configuration_template }}"
+  when:
+    - deprecated_variable.failed is true
+
+- name: Copy fail2ban jail file into place.
   template:
-    src: "{{ security_fail2ban_custom_configuration_template }}"
+    src: "{{ security_fail2ban_jail_template }}"
     dest: /etc/fail2ban/jail.local
     owner: root
     group: root
@@ -24,7 +43,7 @@
 
 - name: Copy fail2ban custom configuration file into place.
   template:
-    src: fail2ban.local.j2
+    src: "{{ security_fail2ban_configuration_template }}"
     dest: /etc/fail2ban/fail2ban.local
     owner: root
     group: root


### PR DESCRIPTION
I reworked this PR: https://github.com/geerlingguy/ansible-role-security/pull/144

It allows users to input their own fail2ban config file. Previously it was only possible to provide a custom jail config.